### PR TITLE
RFC: remove ", or create a new value"

### DIFF
--- a/RFC for Contextualized Manufacturing Information API.md
+++ b/RFC for Contextualized Manufacturing Information API.md
@@ -135,7 +135,7 @@ If the Query specifies an optional query parameter, an implementation MAY suppor
 If the ElementId exists as an instance object, this query MUST return the instance object, conforming to the Type definition the instance object derives from, and including the current value, if present, of any attribute. The returned value payload MUST include the metadata indicated in [section 3.1.1](#311-required-object-metadata) and, if indicated by an optional query parameter, MAY include the metadata indicated in [section 3.1.2](#312-optional-object-metadata).
 
 ### 4.2 Value Methods
-Value methods MAY be used to both Read and Write values in a CMIP, depending on the server implementation. In order to keep this document independent of any specific implementation technology choices, a Read operation shall be referred to as a Query; a Write operation shall be referred to as an Update. An Update may change an existing value, or create a new value in the CMIP.
+Value methods MAY be used to both Read and Write values in a CMIP, depending on the server implementation. In order to keep this document independent of any specific implementation technology choices, a Read operation shall be referred to as a Query; a Write operation shall be referred to as an Update. An Update may change an existing value in the CMIP.
 
 #### 4.2.1 Queries
 
@@ -283,4 +283,5 @@ Implementations of this API MUST be able to return Historical Value responses wi
 ## 6. Acknowledgements
 
 Unless requested otherwise, contributor names and organizations from private previews of this document will be acknowledged in the public release.
+
 


### PR DESCRIPTION
Mutating the models of the CMIP is out of scope for V1, so removing this from the RFC to clarify intention.