### PR TITLE
Matthew gea patch 2

### DIFF
--- a/prototypes/python3/server/data_sources/mock/mock_data.py
+++ b/prototypes/python3/server/data_sources/mock/mock_data.py
@@ -875,7 +875,6 @@ I3X_DATA = {
             "namespaceUri": "https://isa.org/isa95",
             "hasChildren": True,
             "relationships": {
-				"HasParent": [""],
                 "HasChildren": ["cesmii-plant1"],
             },
         },


### PR DESCRIPTION
1) correct parentIDs 
from: `cesmii-plant-1-utilities-water-system-pump-101` to `cesmii-plant-1-utilities-water-system-pump-station-pump-101`

2) replace dashes from the elementID that correspond to space characters