### PR TITLE
Move NS schemas using json pointers, tidy mock value and meta, debug

### DIFF
--- a/prototypes/python3/client/test_client.py
+++ b/prototypes/python3/client/test_client.py
@@ -220,11 +220,12 @@ async def get_relationships(
     if element_id is None:
         raise ValueError("element_id is required to run get_relationships")
     if relationship_type is None:
-        raise ValueError("relationship_type is required to run get_relationships")
-    url += f"/{element_id}/related"
-    params = {"relationshiptype": relationship_type}
+        url += f"/{element_id}/related"
+        json_response = await get(url)
+    else:
+        params = {"relationshiptype": relationship_type}
+        json_response = await get(url, params=params)
 
-    json_response = await get(url, params=params)
     return json_response
 
 
@@ -249,7 +250,7 @@ async def get_object(
 
 
 #######################################
-########### Value Methods #############
+########### Query Methods #############
 #######################################
 async def get_value(
     base_url: str = None, element_id: str = None, include_metadata: bool = False
@@ -460,6 +461,8 @@ async def unsubscribe(base_url: str = None, subscription_id: str = None):
 #######################################
 async def main():
     try:
+        print()
+        print()
         print("Welcome to the CESMII I3X API Test Client.")
         default_url = "http://localhost:8080"
         base_url = input(
@@ -468,7 +471,7 @@ async def main():
         if not base_url:
             base_url = default_url
 
-        selections = "\n1: Exploratory Methods\n2: Value Methods\n3: Update Methods\n4: Subscription Methods \nX: Quit\n"
+        selections = "\n1: Exploratory Methods\n2: Query Methods\n3: Update Methods\n4: Subscription Methods \nX: Quit\n"
 
         ##### MAIN INPUT LOOP #####
         while True:  # broken by user input
@@ -528,7 +531,7 @@ async def main():
                                 raise e
                     elif user_selection == "4":
                         type_id = input(
-                            "Enter Type ElementID (leave blank to return all instance objects): "
+                            "Enter Object Type ElementID (leave blank to return all instance objects): "
                         ).strip()
                         try:
                             pretty_print_json(
@@ -544,7 +547,7 @@ async def main():
                             else:
                                 raise e
                     elif user_selection == "5":
-                        element_id = input("Enter ElementID (required): ").strip()
+                        element_id = input("Enter Object ElementID (required): ").strip()
                         try:
                             pretty_print_json(
                                 await get_object(
@@ -585,8 +588,10 @@ async def main():
                     elif user_selection == "8":
                         element_id = input("Enter ElementID (required): ").strip()
                         relationship_type = input(
-                            "Enter Relationship Type (required, see 'Get Relationship Types'): "
+                            "Enter Relationship Type (leave blank to return all related objects): "
                         ).strip()
+                        if not relationship_type:
+                            relationship_type = None
                         try:
                             pretty_print_json(
                                 await get_relationships(
@@ -610,7 +615,7 @@ async def main():
             elif user_selection == "2":
                 while True:
                     print(
-                        f"Value Methods\n0: Back\n1: Get Last Known Value\n2: Get Historical Values\nX: Quit\n"
+                        f"Query Methods\n0: Back\n1: Get Last Known Value\n2: Get Historical Values\nX: Quit\n"
                     )
                     user_selection = get_user_selection(["0", "1", "2", "X"])
                     if user_selection.upper() == "X":

--- a/prototypes/python3/server/data_sources/data_interface.py
+++ b/prototypes/python3/server/data_sources/data_interface.py
@@ -61,15 +61,26 @@ class I3XDataSource(ABC):
         element_id: str,
         startTime: Optional[str] = None,
         endTime: Optional[str] = None,
+        includeMetadata: bool = False,
+        returnHistory: bool = False,
     ) -> Optional[Dict[str, Any]]:
-        """Return instance object by ElementId"""
+        """
+        Return instance values by ElementId.
+
+        Args:
+            element_id: The element to get values for
+            startTime: Optional start time for filtering
+            endTime: Optional end time for filtering
+            includeMetadata: If True, returns full record with quality and timestamp. If False, returns only the value field(s).
+            returnHistory: If True and no time range specified, returns all historical values. If False, returns only most recent value.
+        """
         pass
 
     @abstractmethod
     def get_related_instances(
-        self, element_id: str, relationship_type: str
+        self, element_id: str, relationship_type: Optional[str] = None
     ) -> List[Dict[str, Any]]:
-        """Return array of objects related by specified relationship type"""
+        """Return array of objects related by specified relationship type. If relationship_type is None, return all related objects."""
         pass
 
     @abstractmethod

--- a/prototypes/python3/server/data_sources/manager.py
+++ b/prototypes/python3/server/data_sources/manager.py
@@ -119,15 +119,15 @@ class DataSourceManager(I3XDataSource):
         source = self._get_source_for_operation("get_instance_by_id")
         return source.get_instance_by_id(element_id)
 
-    def get_instance_values_by_id(self, element_id: str, startTime: Optional[str] = None, endTime: Optional[str] = None) -> Optional[Dict[str, Any]]:
-        """Return instance object by ElementId"""
+    def get_instance_values_by_id(self, element_id: str, startTime: Optional[str] = None, endTime: Optional[str] = None, includeMetadata: bool = False, returnHistory: bool = False) -> Optional[Dict[str, Any]]:
+        """Return instance values by ElementId. If includeMetadata is True, returns full record with quality and timestamp. If False, returns only the value field(s). If returnHistory is True and no time range specified, returns all historical values."""
         source = self._get_source_for_operation("get_instance_by_id")
-        return source.get_instance_values_by_id(element_id, startTime, endTime)
+        return source.get_instance_values_by_id(element_id, startTime, endTime, includeMetadata, returnHistory)
 
     def get_related_instances(
-        self, element_id: str, relationship_type: str
+        self, element_id: str, relationship_type: Optional[str] = None
     ) -> List[Dict[str, Any]]:
-        """Return array of objects related by specified relationship type"""
+        """Return array of objects related by specified relationship type. If relationship_type is None, return all related objects."""
         source = self._get_source_for_operation("get_related_instances")
         return source.get_related_instances(element_id, relationship_type)
 

--- a/prototypes/python3/server/data_sources/mock/Namespaces/abelara.json
+++ b/prototypes/python3/server/data_sources/mock/Namespaces/abelara.json
@@ -1,0 +1,648 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "https://abelara.com/equipment/v1.0",
+    "types": {
+        "state-type": {
+            "type": "object",
+            "properties": {
+                "timestamp": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "color": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "integer"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "description": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "id",
+                        "name",
+                        "description"
+                    ]
+                },
+                "metadata": {
+                    "type": "object",
+                    "properties": {
+                        "source": {
+                            "type": "string"
+                        },
+                        "uri": {
+                            "type": "string"
+                        },
+                        "asset": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "integer"
+                                },
+                                "name": {
+                                    "type": "string"
+                                },
+                                "description": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "id",
+                                "name",
+                                "description"
+                            ]
+                        },
+                        "previousState": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "integer"
+                                },
+                                "name": {
+                                    "type": "string"
+                                },
+                                "description": {
+                                    "type": "string"
+                                },
+                                "color": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {
+                                            "type": "integer"
+                                        },
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "description": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "id",
+                                        "name",
+                                        "description"
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "id",
+                                "name",
+                                "description",
+                                "color",
+                                "type"
+                            ]
+                        },
+                        "additionalInfo": {
+                            "type": "object",
+                            "properties": {
+                                "runTime": {
+                                    "type": "integer"
+                                },
+                                "lastFillTime": {
+                                    "type": "string"
+                                },
+                                "mode": {
+                                    "type": "string"
+                                },
+                                "operator": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "runTime",
+                                "lastFillTime",
+                                "mode",
+                                "operator"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "source",
+                        "uri",
+                        "asset",
+                        "previousState",
+                        "additionalInfo"
+                    ]
+                }
+            },
+            "required": [
+                "timestamp",
+                "description",
+                "color",
+                "type",
+                "metadata"
+            ]
+        },
+        "product-type": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "idealCycleTime": {
+                    "type": "integer"
+                },
+                "tolerance": {
+                    "type": "number"
+                },
+                "unit": {
+                    "type": "string"
+                },
+                "family": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "integer"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "description": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "id",
+                        "name",
+                        "description"
+                    ]
+                }
+            },
+            "required": [
+                "id",
+                "name",
+                "description",
+                "idealCycleTime",
+                "tolerance",
+                "unit",
+                "family"
+            ]
+        },
+        "production-type": {
+            "type": "object",
+            "properties": {
+                "timestamp": {
+                    "type": "string"
+                },
+                "start_ts": {
+                    "type": "string"
+                },
+                "end_ts": {
+                    "type": "null"
+                },
+                "metadata": {
+                    "type": "object",
+                    "properties": {
+                        "timestamp": {
+                            "type": "string"
+                        },
+                        "start_ts": {
+                            "type": "string"
+                        },
+                        "end_ts": {
+                            "type": "null"
+                        },
+                        "counts": {
+                            "type": "array",
+                            "items": [
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "type": "object",
+                                            "properties": {
+                                                "id": {
+                                                    "type": "integer"
+                                                },
+                                                "name": {
+                                                    "type": "string"
+                                                },
+                                                "description": {
+                                                    "type": "string"
+                                                },
+                                                "unit": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "id",
+                                                "name",
+                                                "description",
+                                                "unit"
+                                            ]
+                                        },
+                                        "quantity": {
+                                            "type": "integer"
+                                        },
+                                        "timestamp": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "type",
+                                        "quantity",
+                                        "timestamp"
+                                    ]
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "type": "object",
+                                            "properties": {
+                                                "id": {
+                                                    "type": "integer"
+                                                },
+                                                "name": {
+                                                    "type": "string"
+                                                },
+                                                "description": {
+                                                    "type": "string"
+                                                },
+                                                "unit": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "id",
+                                                "name",
+                                                "description",
+                                                "unit"
+                                            ]
+                                        },
+                                        "quantity": {
+                                            "type": "integer"
+                                        },
+                                        "timestamp": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "type",
+                                        "quantity",
+                                        "timestamp"
+                                    ]
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "type": "object",
+                                            "properties": {
+                                                "id": {
+                                                    "type": "integer"
+                                                },
+                                                "name": {
+                                                    "type": "string"
+                                                },
+                                                "description": {
+                                                    "type": "string"
+                                                },
+                                                "unit": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "id",
+                                                "name",
+                                                "description",
+                                                "unit"
+                                            ]
+                                        },
+                                        "quantity": {
+                                            "type": "number"
+                                        },
+                                        "timestamp": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "type",
+                                        "quantity",
+                                        "timestamp"
+                                    ]
+                                }
+                            ]
+                        },
+                        "metadata": {
+                            "type": "object",
+                            "properties": {
+                                "source": {
+                                    "type": "string"
+                                },
+                                "uri": {
+                                    "type": "string"
+                                },
+                                "asset": {
+                                    "type": "object",
+                                    "!related": {
+                                        "relationshipType": "ComposedOf",
+                                        "type": "https://abelara.com/equipment:product-type"
+                                    },
+                                    "product": {
+                                        "$ref": "#/types/product-type"
+                                    },
+                                    "properties": {
+                                        "id": {
+                                            "type": "integer"
+                                        },
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "description": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "id",
+                                        "name",
+                                        "description"
+                                    ]
+                                },
+                                "additionalInfo": {
+                                    "type": "object",
+                                    "properties": {
+                                        "shift": {
+                                            "type": "string"
+                                        },
+                                        "operator": {
+                                            "type": "string"
+                                        },
+                                        "demandLevel": {
+                                            "type": "string"
+                                        },
+                                        "systemEfficiency": {
+                                            "type": "number"
+                                        },
+                                        "energyConsumption": {
+                                            "type": "number"
+                                        },
+                                        "qualityScore": {
+                                            "type": "number"
+                                        },
+                                        "plannedProduction": {
+                                            "type": "integer"
+                                        },
+                                        "actualProduction": {
+                                            "type": "integer"
+                                        },
+                                        "efficiency": {
+                                            "type": "number"
+                                        }
+                                    },
+                                    "required": [
+                                        "shift",
+                                        "operator",
+                                        "demandLevel",
+                                        "systemEfficiency",
+                                        "energyConsumption",
+                                        "qualityScore",
+                                        "plannedProduction",
+                                        "actualProduction",
+                                        "efficiency"
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "source",
+                                "uri",
+                                "asset",
+                                "additionalInfo"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "timestamp",
+                        "start_ts",
+                        "end_ts",
+                        "counts",
+                        "metadata"
+                    ]
+                }
+            },
+            "required": [
+                "timestamp",
+                "start_ts",
+                "end_ts",
+                "counts",
+                "metadata"
+            ]
+        },
+        "measurements-type": {
+            "properties": {
+                "measurements": {
+                    "type": "array",
+                    "items": {}
+                }
+            },
+            "required": [
+                "measurements"
+            ]
+        },
+        "measurement-type": {
+            "properties": {
+                "timestamp": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "integer"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "description": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "id",
+                        "name",
+                        "description"
+                    ]
+                },
+                "value": "#/types/measurement-value-type",
+                "health": "#/types/measurement-other-value-type",
+                "unit": {
+                    "type": "string"
+                },
+                "target": {
+                    "type": "number"
+                },
+                "tolerance": {
+                    "type": "number"
+                },
+                "inTolerance": {
+                    "type": "boolean"
+                },
+                "metadata": {
+                    "type": "object",
+                    "properties": {
+                        "source": {
+                            "type": "string"
+                        },
+                        "uri": {
+                            "type": "string"
+                        },
+                        "asset": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "integer"
+                                },
+                                "name": {
+                                    "type": "string"
+                                },
+                                "description": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "id",
+                                "name",
+                                "description"
+                            ]
+                        },
+                        "additionalInfo": {
+                            "type": "object",
+                            "properties": {
+                                "technician": {
+                                    "type": "string"
+                                },
+                                "measurementMethod": {
+                                    "type": "string"
+                                },
+                                "equipmentUsed": {
+                                    "type": "string"
+                                },
+                                "measurementDate": {
+                                    "type": "string"
+                                },
+                                "nextMeasurementDue": {
+                                    "type": "string"
+                                },
+                                "trend": {
+                                    "type": "string"
+                                },
+                                "measurementLocation": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "technician",
+                                "measurementMethod",
+                                "equipmentUsed",
+                                "measurementDate",
+                                "nextMeasurementDue",
+                                "trend",
+                                "measurementLocation"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "source",
+                        "uri",
+                        "asset",
+                        "additionalInfo"
+                    ]
+                },
+                "product": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "integer"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "description": {
+                            "type": "string"
+                        },
+                        "family": {
+                            "type": "JSON",
+                            "properties": {
+                                "id": {
+                                    "type": "integer"
+                                },
+                                "name": {
+                                    "type": "string"
+                                },
+                                "description": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "id",
+                                "name",
+                                "description"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "id",
+                        "name",
+                        "description",
+                        "family"
+                    ]
+                },
+                "productionContext": {
+                    "type": "object",
+                    "properties": {
+                        "batchId": {
+                            "type": "string"
+                        },
+                        "processStep": {
+                            "type": "string"
+                        },
+                        "demand": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "batchId",
+                        "processStep",
+                        "demand"
+                    ]
+                }
+            },
+            "required": [
+                "timestamp",
+                "type",
+                "value",
+                "unit",
+                "target",
+                "tolerance",
+                "inTolerance",
+                "metadata",
+                "product",
+                "productionContext"
+            ]
+        },
+        "measurement-value-type": {
+            "type": "number"
+        },
+        "measurement-health-type": {
+            "type": "integer"
+        }
+    }
+}

--- a/prototypes/python3/server/data_sources/mock/Namespaces/isa95.json
+++ b/prototypes/python3/server/data_sources/mock/Namespaces/isa95.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "https://abelara.com/equipment/v1.0",
+    "types": {
+        "work-unit-type": {
+            "type": "object"
+        }
+    }
+}

--- a/prototypes/python3/server/data_sources/mock/Namespaces/thinkiq.json
+++ b/prototypes/python3/server/data_sources/mock/Namespaces/thinkiq.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "https://thinkiq.com/equipment/v1.0",
+    "types": {
+        "sensor-type": {
+            "type": "object",
+            "properties": {
+                "value": {"type": "number"},
+                "engUnit": {"type": "string"},
+                "status": {"type": "string"},
+                "calibrationDate": {"type": "string"}
+            },
+            "required": ["value", "engUnit", "status"]
+        }
+    }
+}

--- a/prototypes/python3/server/data_sources/mock/mock_data.py
+++ b/prototypes/python3/server/data_sources/mock/mock_data.py
@@ -1,2041 +1,498 @@
 from datetime import datetime
 
-# I3X API compliant mock data - Industrial Information Interface eXchange (RFC 001)
+# SIMPLIFIED I3X API compliant mock data - Industrial Information Interface eXchange (RFC 001)
 I3X_DATA = {
     "namespaces": [
         {"uri": "https://cesmii.org/i3x", "displayName": "I3X"},
         {"uri": "https://isa.org/isa95", "displayName": "ISA95"},
         {"uri": "https://abelara.com/equipment", "displayName": "Abelara Equipment"},
-        {"uri": "https://thinkiq.com/equipment", "displayName": "ThinkIQ Equipment"},
-        {
-            "uri": "http://opcfoundation.org/UA/Machinery",
-            "displayName": "OPC UA for Machinery",
-        },
+        {"uri": "https://thinkiq.com/equipment", "displayName": "ThinkIQ Equipment"}
     ],
     "objectTypes": [
         {
-            "elementId": "enterprise-type",
-            "displayName": "Enterprise",
-            "namespaceUri": "https://isa.org/isa95",
-            "schema": {
-                "$schema": "http://json-schema.org/draft-04/schema#",
-                "type": "object",
-                "properties": {"site": {"type": "array", "items": {}}},
-                "required": ["site"],
-            },
-        },
-        {
-            "elementId": "site-type",
-            "displayName": "Site",
-            "namespaceUri": "https://isa.org/isa95",
-            "schema": {
-                "$schema": "http://json-schema.org/draft-04/schema#",
-                "type": "object",
-                "properties": {"area": {"type": "array", "items": {}}},
-                "required": ["area"],
-            },
-        },
-        {
-            "elementId": "area-type",
-            "displayName": "Area",
-            "namespaceUri": "https://isa.org/isa95",
-            "schema": {
-                "$schema": "http://json-schema.org/draft-04/schema#",
-                "type": "object",
-                "properties": {"work-center": {"type": "array", "items": {}}},
-                "required": ["work-center"],
-            },
-        },
-        {
-            "elementId": "work-center-type",
-            "displayName": "Work-Center",
-            "namespaceUri": "https://isa.org/isa95",
-            "schema": {
-                "$schema": "http://json-schema.org/draft-04/schema#",
-                "type": "object",
-                "properties": {"work-unit": {"type": "array", "items": {}}},
-                "required": ["work-unit"],
-            },
-        },
-        {
             "elementId": "work-unit-type",
-            "displayName": "Work-Unit",
+            "displayName": "WorkUnitType",
             "namespaceUri": "https://isa.org/isa95",
-            "schema": {
-                "$schema": "http://json-schema.org/draft-04/schema#",
-                "type": "object",
-            },
+            "schema": "Namespaces/isa95.json#types/work-unit-type",
         },
         {
             "elementId": "state-type",
-            "displayName": "State",
+            "displayName": "StateType",
             "namespaceUri": "https://abelara.com/equipment",
-            "schema": {
-                "$schema": "http://json-schema.org/draft-04/schema#",
-                "type": "object",
-                "properties": {
-                    "timestamp": {"type": "string"},
-                    "description": {"type": "string"},
-                    "color": {"type": "string"},
-                    "type": {
-                        "type": "object",
-                        "properties": {
-                            "id": {"type": "integer"},
-                            "name": {"type": "string"},
-                            "description": {"type": "string"},
-                        },
-                        "required": ["id", "name", "description"],
-                    },
-                    "metadata": {
-                        "type": "object",
-                        "properties": {
-                            "source": {"type": "string"},
-                            "uri": {"type": "string"},
-                            "asset": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {"type": "integer"},
-                                    "name": {"type": "string"},
-                                    "description": {"type": "string"},
-                                },
-                                "required": ["id", "name", "description"],
-                            },
-                            "previousState": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {"type": "integer"},
-                                    "name": {"type": "string"},
-                                    "description": {"type": "string"},
-                                    "color": {"type": "string"},
-                                    "type": {
-                                        "type": "object",
-                                        "properties": {
-                                            "id": {"type": "integer"},
-                                            "name": {"type": "string"},
-                                            "description": {"type": "string"},
-                                        },
-                                        "required": ["id", "name", "description"],
-                                    },
-                                },
-                                "required": [
-                                    "id",
-                                    "name",
-                                    "description",
-                                    "color",
-                                    "type",
-                                ],
-                            },
-                            "additionalInfo": {
-                                "type": "object",
-                                "properties": {
-                                    "runTime": {"type": "integer"},
-                                    "lastFillTime": {"type": "string"},
-                                    "mode": {"type": "string"},
-                                    "operator": {"type": "string"},
-                                },
-                                "required": [
-                                    "runTime",
-                                    "lastFillTime",
-                                    "mode",
-                                    "operator",
-                                ],
-                            },
-                        },
-                        "required": [
-                            "source",
-                            "uri",
-                            "asset",
-                            "previousState",
-                            "additionalInfo",
-                        ],
-                    },
-                },
-                "required": ["timestamp", "description", "color", "type", "metadata"],
-            },
-        },
-        {
-            "elementId": "alert-type",
-            "displayName": "Alert",
-            "namespaceUri": "https://abelara.com/equipment",
-            "schema": {
-                "$schema": "http://json-schema.org/draft-04/schema#",
-                "type": "object",
-                "properties": {
-                    "timestamp": {"type": "string"},
-                    "severity": {"type": "integer"},
-                    "code": {"type": "string"},
-                    "message": {"type": "string"},
-                    "metadata": {
-                        "type": "object",
-                        "properties": {
-                            "source": {"type": "string"},
-                            "uri": {"type": "string"},
-                            "asset": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {"type": "integer"},
-                                    "name": {"type": "string"},
-                                    "description": {"type": "string"},
-                                },
-                                "required": ["id", "name", "description"],
-                            },
-                            "acknowledgment": {
-                                "type": "object",
-                                "properties": {
-                                    "acknowledged": {"type": "boolean"},
-                                    "acknowledgedBy": {"type": "null"},
-                                    "acknowledgedAt": {"type": "null"},
-                                },
-                                "required": [
-                                    "acknowledged",
-                                    "acknowledgedBy",
-                                    "acknowledgedAt",
-                                ],
-                            },
-                            "additionalInfo": {
-                                "type": "object",
-                                "properties": {
-                                    "temperature": {"type": "number"},
-                                    "warningThreshold": {"type": "number"},
-                                    "alarmThreshold": {"type": "number"},
-                                    "sensorLocation": {"type": "string"},
-                                    "trend": {"type": "string"},
-                                    "timeInAlarm": {"type": "integer"},
-                                    "recommendedAction": {"type": "string"},
-                                    "priority": {"type": "string"},
-                                },
-                                "required": [
-                                    "temperature",
-                                    "warningThreshold",
-                                    "alarmThreshold",
-                                    "sensorLocation",
-                                    "trend",
-                                    "timeInAlarm",
-                                    "recommendedAction",
-                                    "priority",
-                                ],
-                            },
-                        },
-                        "required": [
-                            "source",
-                            "uri",
-                            "asset",
-                            "acknowledgment",
-                            "additionalInfo",
-                        ],
-                    },
-                },
-                "required": ["timestamp", "severity", "code", "message", "metadata"],
-            },
+            "schema": "Namespaces/abelara.json#types/state-type",
         },
         {
             "elementId": "product-type",
-            "displayName": "Product",
+            "displayName": "ProductType",
             "namespaceUri": "https://abelara.com/equipment",
-            "schema": {
-                "$schema": "http://json-schema.org/draft-04/schema#",
-                "type": "object",
-                "properties": {
-                    "timestamp": {"type": "string"},
-                    "id": {"type": "integer"},
-                    "name": {"type": "string"},
-                    "description": {"type": "string"},
-                    "idealCycleTime": {"type": "integer"},
-                    "tolerance": {"type": "number"},
-                    "unit": {"type": "string"},
-                    "family": {
-                        "type": "object",
-                        "properties": {
-                            "id": {"type": "integer"},
-                            "name": {"type": "string"},
-                            "description": {"type": "string"},
-                        },
-                        "required": ["id", "name", "description"],
-                    },
-                    "metadata": {
-                        "type": "object",
-                        "properties": {
-                            "source": {"type": "string"},
-                            "uri": {"type": "string"},
-                            "asset": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {"type": "integer"},
-                                    "name": {"type": "string"},
-                                    "description": {"type": "string"},
-                                },
-                                "required": ["id", "name", "description"],
-                            },
-                            "additionalInfo": {
-                                "type": "object",
-                                "properties": {
-                                    "specifications": {
-                                        "type": "object",
-                                        "properties": {
-                                            "temperature": {"type": "string"},
-                                            "pressure": {"type": "string"},
-                                            "quality": {"type": "string"},
-                                            "chlorinated": {"type": "boolean"},
-                                        },
-                                        "required": [
-                                            "temperature",
-                                            "pressure",
-                                            "quality",
-                                            "chlorinated",
-                                        ],
-                                    },
-                                    "regulatoryCompliance": {
-                                        "type": "array",
-                                        "items": [
-                                            {"type": "string"},
-                                            {"type": "string"},
-                                        ],
-                                    },
-                                },
-                                "required": ["specifications", "regulatoryCompliance"],
-                            },
-                        },
-                        "required": ["source", "uri", "asset", "additionalInfo"],
-                    },
-                },
-                "required": [
-                    "timestamp",
-                    "id",
-                    "name",
-                    "description",
-                    "idealCycleTime",
-                    "tolerance",
-                    "unit",
-                    "family",
-                    "metadata",
-                ],
-            },
+            "schema": "Namespaces/abelara.json#types/product-type",
         },
         {
             "elementId": "production-type",
-            "displayName": "Production",
+            "displayName": "ProductionType",
             "namespaceUri": "https://abelara.com/equipment",
-            "schema": {
-                "$schema": "http://json-schema.org/draft-04/schema#",
-                "type": "object",
-                "properties": {
-                    "timestamp": {"type": "string"},
-                    "start_ts": {"type": "string"},
-                    "end_ts": {"type": "null"},
-                    "counts": {
-                        "type": "array",
-                        "items": [
-                            {
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "object",
-                                        "properties": {
-                                            "id": {"type": "integer"},
-                                            "name": {"type": "string"},
-                                            "description": {"type": "string"},
-                                            "unit": {"type": "string"},
-                                        },
-                                        "required": [
-                                            "id",
-                                            "name",
-                                            "description",
-                                            "unit",
-                                        ],
-                                    },
-                                    "quantity": {"type": "integer"},
-                                    "timestamp": {"type": "string"},
-                                },
-                                "required": ["type", "quantity", "timestamp"],
-                            },
-                            {
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "object",
-                                        "properties": {
-                                            "id": {"type": "integer"},
-                                            "name": {"type": "string"},
-                                            "description": {"type": "string"},
-                                            "unit": {"type": "string"},
-                                        },
-                                        "required": [
-                                            "id",
-                                            "name",
-                                            "description",
-                                            "unit",
-                                        ],
-                                    },
-                                    "quantity": {"type": "number"},
-                                    "timestamp": {"type": "string"},
-                                },
-                                "required": ["type", "quantity", "timestamp"],
-                            },
-                        ],
-                    },
-                    "metadata": {
-                        "type": "object",
-                        "properties": {
-                            "source": {"type": "string"},
-                            "uri": {"type": "string"},
-                            "asset": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {"type": "integer"},
-                                    "name": {"type": "string"},
-                                    "description": {"type": "string"},
-                                },
-                                "required": ["id", "name", "description"],
-                            },
-                            "product": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {"type": "integer"},
-                                    "name": {"type": "string"},
-                                    "description": {"type": "string"},
-                                    "idealCycleTime": {"type": "integer"},
-                                    "tolerance": {"type": "number"},
-                                    "unit": {"type": "string"},
-                                    "family": {
-                                        "type": "object",
-                                        "properties": {
-                                            "id": {"type": "integer"},
-                                            "name": {"type": "string"},
-                                            "description": {"type": "string"},
-                                        },
-                                        "required": ["id", "name", "description"],
-                                    },
-                                },
-                                "required": [
-                                    "id",
-                                    "name",
-                                    "description",
-                                    "idealCycleTime",
-                                    "tolerance",
-                                    "unit",
-                                    "family",
-                                ],
-                            },
-                            "additionalInfo": {
-                                "type": "object",
-                                "properties": {
-                                    "shift": {"type": "string"},
-                                    "operator": {"type": "string"},
-                                    "demandLevel": {"type": "string"},
-                                    "systemEfficiency": {"type": "number"},
-                                    "energyConsumption": {"type": "number"},
-                                    "qualityScore": {"type": "number"},
-                                    "plannedProduction": {"type": "integer"},
-                                    "actualProduction": {"type": "integer"},
-                                    "efficiency": {"type": "number"},
-                                },
-                                "required": [
-                                    "shift",
-                                    "operator",
-                                    "demandLevel",
-                                    "systemEfficiency",
-                                    "energyConsumption",
-                                    "qualityScore",
-                                    "plannedProduction",
-                                    "actualProduction",
-                                    "efficiency",
-                                ],
-                            },
-                        },
-                        "required": [
-                            "source",
-                            "uri",
-                            "asset",
-                            "product",
-                            "additionalInfo",
-                        ],
-                    },
-                },
-                "required": ["timestamp", "start_ts", "end_ts", "counts", "metadata"],
-            },
+            "schema": "Namespaces/abelara.json#types/production-type",
         },
         {
             "elementId": "measurements-type",
-            "displayName": "Measurements",
+            "displayName": "MeasurementsType",
             "namespaceUri": "https://abelara.com/equipment",
-            "schema": {
-                "$schema": "http://json-schema.org/draft-04/schema#",
-                "type": "object",
-                "properties": {"measurements": {"type": "array", "items": {}}},
-                "required": ["measurements"],
-            },
+            "schema": "Namespaces/abelara.json#types/measurements-type"
         },
         {
             "elementId": "measurement-type",
-            "displayName": "Measurement",
+            "displayName": "MeasurementType",
             "namespaceUri": "https://abelara.com/equipment",
-            "schema": {
-                "$schema": "http://json-schema.org/draft-04/schema#",
-                "type": "object",
-                "properties": {
-                    "timestamp": {"type": "string"},
-                    "type": {
-                        "type": "object",
-                        "properties": {
-                            "id": {"type": "integer"},
-                            "name": {"type": "string"},
-                            "description": {"type": "string"},
-                        },
-                        "required": ["id", "name", "description"],
-                    },
-                    "value": {"type": "number"},
-                    "unit": {"type": "string"},
-                    "target": {"type": "number"},
-                    "tolerance": {"type": "number"},
-                    "inTolerance": {"type": "boolean"},
-                    "metadata": {
-                        "type": "object",
-                        "properties": {
-                            "source": {"type": "string"},
-                            "uri": {"type": "string"},
-                            "asset": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {"type": "integer"},
-                                    "name": {"type": "string"},
-                                    "description": {"type": "string"},
-                                },
-                                "required": ["id", "name", "description"],
-                            },
-                            "additionalInfo": {
-                                "type": "object",
-                                "properties": {
-                                    "technician": {"type": "string"},
-                                    "measurementMethod": {"type": "string"},
-                                    "equipmentUsed": {"type": "string"},
-                                    "measurementDate": {"type": "string"},
-                                    "nextMeasurementDue": {"type": "string"},
-                                    "trend": {"type": "string"},
-                                    "measurementLocation": {"type": "string"},
-                                },
-                                "required": [
-                                    "technician",
-                                    "measurementMethod",
-                                    "equipmentUsed",
-                                    "measurementDate",
-                                    "nextMeasurementDue",
-                                    "trend",
-                                    "measurementLocation",
-                                ],
-                            },
-                        },
-                        "required": ["source", "uri", "asset", "additionalInfo"],
-                    },
-                    "product": {
-                        "type": "object",
-                        "properties": {
-                            "id": {"type": "integer"},
-                            "name": {"type": "string"},
-                            "description": {"type": "string"},
-                            "family": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {"type": "integer"},
-                                    "name": {"type": "string"},
-                                    "description": {"type": "string"},
-                                },
-                                "required": ["id", "name", "description"],
-                            },
-                        },
-                        "required": ["id", "name", "description", "family"],
-                    },
-                    "productionContext": {
-                        "type": "object",
-                        "properties": {
-                            "batchId": {"type": "string"},
-                            "processStep": {"type": "string"},
-                            "demand": {"type": "string"},
-                        },
-                        "required": ["batchId", "processStep", "demand"],
-                    },
-                },
-                "required": [
-                    "timestamp",
-                    "type",
-                    "value",
-                    "unit",
-                    "target",
-                    "tolerance",
-                    "inTolerance",
-                    "metadata",
-                    "product",
-                    "productionContext",
-                ],
-            },
+            "schema": "Namespaces/abelara.json#types/measurement-type"
         },
         {
-            "elementId": "count-type",
-            "displayName": "Count",
+            "elementId": "measurement-value-type",
+            "displayName": "MeasurementValueType",
             "namespaceUri": "https://abelara.com/equipment",
-            "schema": {
-                "$schema": "http://json-schema.org/draft-04/schema#",
-                "type": "object",
-                "properties": {
-                    "timestamp": {"type": "string"},
-                    "value": {"type": "number"},
-                    "unit": {"type": "string"},
-                    "type": {
-                        "type": "object",
-                        "properties": {
-                            "id": {"type": "integer"},
-                            "name": {"type": "string"},
-                            "description": {"type": "string"},
-                        },
-                        "required": ["id", "name", "description"],
-                    },
-                    "metadata": {
-                        "type": "object",
-                        "properties": {
-                            "source": {"type": "string"},
-                            "uri": {"type": "string"},
-                            "asset": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {"type": "integer"},
-                                    "name": {"type": "string"},
-                                    "description": {"type": "string"},
-                                },
-                                "required": ["id", "name", "description"],
-                            },
-                            "production": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {"type": "integer"},
-                                    "name": {"type": "string"},
-                                    "description": {"type": "string"},
-                                },
-                                "required": ["id", "name", "description"],
-                            },
-                            "product": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {"type": "integer"},
-                                    "name": {"type": "string"},
-                                    "description": {"type": "string"},
-                                },
-                                "required": ["id", "name", "description"],
-                            },
-                            "additionalInfo": {
-                                "type": "object",
-                                "properties": {
-                                    "maintenanceDue": {"type": "integer"},
-                                    "lastMaintenance": {"type": "string"},
-                                    "nextMaintenance": {"type": "string"},
-                                    "flowRate": {"type": "number"},
-                                    "efficiency": {"type": "number"},
-                                    "totalEnergy": {"type": "number"},
-                                    "increment": {"type": "number"},
-                                    "lastReset": {"type": "string"},
-                                    "nextReset": {"type": "string"},
-                                },
-                                "required": [
-                                    "maintenanceDue",
-                                    "lastMaintenance",
-                                    "nextMaintenance",
-                                    "flowRate",
-                                    "efficiency",
-                                    "totalEnergy",
-                                    "increment",
-                                    "lastReset",
-                                    "nextReset",
-                                ],
-                            },
-                        },
-                        "required": [
-                            "source",
-                            "uri",
-                            "asset",
-                            "production",
-                            "product",
-                            "additionalInfo",
-                        ],
-                    },
-                },
-                "required": ["timestamp", "value", "unit", "type", "metadata"],
-            },
+            "schema": "Namespaces/abelara.json#types/measurement-value-type"
         },
         {
-            "elementId": "kpi-type",
-            "displayName": "KPI",
+            "elementId": "measurement-health-type",
+            "displayName": "MeasurementHealthType",
             "namespaceUri": "https://abelara.com/equipment",
-            "schema": {
-                "$schema": "http://json-schema.org/draft-04/schema#",
-                "type": "object",
-                "properties": {
-                    "timestamp": {"type": "string"},
-                    "value": {"type": "number"},
-                    "unit": {"type": "string"},
-                    "type": {
-                        "type": "object",
-                        "properties": {
-                            "id": {"type": "integer"},
-                            "name": {"type": "string"},
-                            "description": {"type": "string"},
-                        },
-                        "required": ["id", "name", "description"],
-                    },
-                    "product": {
-                        "type": "object",
-                        "properties": {
-                            "id": {"type": "integer"},
-                            "name": {"type": "string"},
-                            "description": {"type": "string"},
-                            "family": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {"type": "integer"},
-                                    "name": {"type": "string"},
-                                    "description": {"type": "string"},
-                                },
-                                "required": ["id", "name", "description"],
-                            },
-                        },
-                        "required": ["id", "name", "description", "family"],
-                    },
-                    "metadata": {
-                        "type": "object",
-                        "properties": {
-                            "source": {"type": "string"},
-                            "uri": {"type": "string"},
-                            "asset": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {"type": "integer"},
-                                    "name": {"type": "string"},
-                                },
-                                "required": ["id", "name"],
-                            },
-                            "additionalInfo": {
-                                "type": "object",
-                                "properties": {
-                                    "calculationPeriod": {"type": "string"},
-                                    "inputPower": {"type": "number"},
-                                    "outputPower": {"type": "number"},
-                                    "targetEfficiency": {"type": "number"},
-                                    "trend": {"type": "string"},
-                                    "lastCalculation": {"type": "string"},
-                                    "baselineValue": {"type": "number"},
-                                    "improvement": {"type": "number"},
-                                },
-                                "required": [
-                                    "calculationPeriod",
-                                    "inputPower",
-                                    "outputPower",
-                                    "targetEfficiency",
-                                    "trend",
-                                    "lastCalculation",
-                                    "baselineValue",
-                                    "improvement",
-                                ],
-                            },
-                        },
-                        "required": ["source", "uri", "asset", "additionalInfo"],
-                    },
-                },
-                "required": [
-                    "timestamp",
-                    "value",
-                    "unit",
-                    "type",
-                    "product",
-                    "metadata",
-                ],
-            },
-        },
-        {
-            "elementId": "measurement-type",
-            "displayName": "Measurement",
-            "namespaceUri": "https://abelara.com/equipment",
-            "schema": {
-                "$schema": "http://json-schema.org/draft-04/schema#",
-                "type": "object",
-                "properties": {
-                    "timestamp": {"type": "string"},
-                    "type": {
-                        "type": "object",
-                        "properties": {
-                            "id": {"type": "integer"},
-                            "name": {"type": "string"},
-                            "description": {"type": "string"},
-                        },
-                        "required": ["id", "name", "description"],
-                    },
-                    "value": {"type": "number"},
-                    "unit": {"type": "string"},
-                    "target": {"type": "number"},
-                    "tolerance": {"type": "number"},
-                    "inTolerance": {"type": "boolean"},
-                    "metadata": {
-                        "type": "object",
-                        "properties": {
-                            "source": {"type": "string"},
-                            "uri": {"type": "string"},
-                            "asset": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {"type": "integer"},
-                                    "name": {"type": "string"},
-                                    "description": {"type": "string"},
-                                },
-                                "required": ["id", "name", "description"],
-                            },
-                            "additionalInfo": {
-                                "type": "object",
-                                "properties": {
-                                    "technician": {"type": "string"},
-                                    "measurementMethod": {"type": "string"},
-                                    "equipmentUsed": {"type": "string"},
-                                    "measurementDate": {"type": "string"},
-                                    "nextMeasurementDue": {"type": "string"},
-                                    "trend": {"type": "string"},
-                                    "measurementLocation": {"type": "string"},
-                                },
-                                "required": [
-                                    "technician",
-                                    "measurementMethod",
-                                    "equipmentUsed",
-                                    "measurementDate",
-                                    "nextMeasurementDue",
-                                    "trend",
-                                    "measurementLocation",
-                                ],
-                            },
-                        },
-                        "required": ["source", "uri", "asset", "additionalInfo"],
-                    },
-                    "product": {
-                        "type": "object",
-                        "properties": {
-                            "id": {"type": "integer"},
-                            "name": {"type": "string"},
-                            "description": {"type": "string"},
-                            "family": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {"type": "integer"},
-                                    "name": {"type": "string"},
-                                    "description": {"type": "string"},
-                                },
-                                "required": ["id", "name", "description"],
-                            },
-                        },
-                        "required": ["id", "name", "description", "family"],
-                    },
-                    "productionContext": {
-                        "type": "object",
-                        "properties": {
-                            "batchId": {"type": "string"},
-                            "processStep": {"type": "string"},
-                            "demand": {"type": "string"},
-                        },
-                        "required": ["batchId", "processStep", "demand"],
-                    },
-                },
-                "required": [
-                    "timestamp",
-                    "type",
-                    "value",
-                    "unit",
-                    "target",
-                    "tolerance",
-                    "inTolerance",
-                    "metadata",
-                    "product",
-                    "productionContext",
-                ],
-            },
+            "schema": "Namespaces/abelara.json#types/measurement-health-type"
         },
         {
             "elementId": "sensor-type",
-            "displayName": "Measurements",
+            "displayName": "SensorType",
             "namespaceUri": "https://thinkiq.com/equipment",
-            "schema": {
-                "$schema": "http://json-schema.org/draft-04/schema#",
-                "type": "object",
-                "properties": {
-                    "value": {"type": "number"},
-                    "engUnit": {"type": "string"},
-                    "status": {"type": "string"},
-                    "calibrationDate": {"type": "string"},
-                },
-                "required": ["value", "engUnit", "status"],
-            },
+            "schema": "Namespaces/thinkiq.json#types/sensor-type"
         },
     ],
     "instances": [
         {
-            "elementId": "cesmii",
-            "displayName": "CESMII",
-            "typeId": "enterprise-type",
-            "namespaceUri": "https://isa.org/isa95",
-            "hasChildren": True,
-            "relationships": {
-                "HasChildren": ["cesmii-plant1"],
-            },
-        },
-        {
-            "elementId": "cesmii-plant1",
-            "displayName": "Plant 1",
-            "typeId": "site-type",
-            "namespaceUri": "https://isa.org/isa95",
-            "hasChildren": True,
-            "relationships": {
-                "HasParent": ["cesmii"],
-                "HasChildren": ["cesmii-plant1-utilities"],
-            },
-        },
-        {
-            "elementId": "cesmii-plant1-utilities",
-            "displayName": "Utilities",
-            "typeId": "area-type",
-            "namespaceUri": "https://isa.org/isa95",
-            "hasChildren": True,
-            "relationships": {
-                "HasParent": ["cesmii-plant1"],
-                "HasChildren": ["cesmii-plant1-utilities-watersystem"],
-            },
-        },
-        {
-            "elementId": "cesmii-plant1-utilities-watersystem",
-            "displayName": "Water System",
-            "typeId": "work-center-type",
-            "namespaceUri": "https://isa.org/isa95",
-            "hasChildren": True,
-            "relationships": {
-                "HasParent": ["cesmii-plant1-utilities"],
-                "HasChildren": ["cesmii-plant1-utilities-watersystem-pumpstation"],
-            },
-        },
-        {
-            "elementId": "cesmii-plant1-utilities-watersystem-pumpstation",
-            "displayName": "Pump Station",
-            "typeId": "work-center-type",
-            "namespaceUri": "https://isa.org/isa95",
-            "hasChildren": True,
-            "relationships": {
-                "HasParent": ["cesmii-plant1-utilities-watersystem"],
-                "HasChildren": [
-                    "cesmii-plant1-utilities-watersystem-pumpstation-pump101"
-                ],
-            },
-        },
-        {
-            "elementId": "cesmii-plant1-utilities-watersystem-pumpstation-pump101",
+            "elementId": "pump-101",
             "displayName": "pump-101",
-            "typeId": "work-unit-type",
             "namespaceUri": "https://isa.org/isa95",
+            "typeId": "work-unit-type",
+            #These two fields are required in the response so placed in the mock data for readability
+            # A platform implementation would read its graph in order to populate these required response fields.
+            "parentId": "/",
             "hasChildren": True,
+            #This is where we maintain the graph relationships used above and in the /related endpoints
             "relationships": {
-                "HasParent": ["cesmii-plant1-utilities-watersystem-pumpstation"],
+                "HasParent": "/",
                 "HasChildren": [
                     "pump-101-state",
-                    "pump-101-alert",
-                    "pump-101-product",
                     "pump-101-production",
-                    "pump-101-measurements",
+                    "pump-101-measurements"
                 ],
                 "SuppliesTo": ["tank-201"],
             },
+            # Optional property or attribute metadata (extra fields, per RFC 3.1.2 bullet 4)
+            "operationStartDate": "July 1, 1980",
+            "lastMaintainedDate": "August 1, 2001"
         },
         {
             "elementId": "pump-101-state",
             "displayName": "pump-101 State",
+            "namespaceUri": "https://abelara.com/equipment",
             "typeId": "state-type",
-            "namespaceUri": "https://abelara.com/equipment",
+            "parentId": "pump-101",
             "hasChildren": False,
             "relationships": {
-                "HasParent": ["cesmii-plant1-utilities-watersystem-pumpstation-pump101"],
+                "HasParent": "pump-101",
             },
-            "values": [
+            "records": [
                 {
-                    "timestamp": "2025-10-29T18:20:44.779036+00:00",
-                    "description": "Pump is in maintenance",
-                    "color": "#800080",
-                    "type": {
-                        "id": 5,
-                        "name": "Maintenance",
-                        "description": "Equipment under maintenance",
-                    },
-                    "metadata": {
-                        "source": "plc-controller",
-                        "uri": "opc://plc1/DB1.DBW0",
-                        "asset": {
-                            "id": 101,
-                            "name": "Pump-101",
-                            "description": "Centrifugal water pump for cooling system",
+                    "value": {
+                        "timestamp": "2025-10-29T18:20:44.779036+00:00",
+                        "description": "Pump is in maintenance",
+                        "color": "#800080",
+                        "type": {
+                            "id": 5,
+                            "name": "Maintenance",
+                            "description": "Equipment under maintenance",
                         },
-                    },
-                },
-                {
-                    "timestamp": "2025-10-28T18:20:44.779036+00:00",
-                    "description": "Pump is in operation",
-                    "color": "#00FF00",
-                    "type": {
-                        "id": 1,
-                        "name": "Operating",
-                        "description": "Equipment operating normally",
-                    },
-                    "metadata": {
-                        "source": "plc-controller",
-                        "uri": "opc://plc1/DB1.DBW0",
-                        "asset": {
-                            "id": 101,
-                            "name": "Pump-101",
-                            "description": "Centrifugal water pump for cooling system",
-                        },
-                    },
-                },
-                {
-                    "timestamp": "2025-10-27T18:20:44.779036+00:00",
-                    "description": "Pump is in operation",
-                    "color": "#FFFF00",
-                    "type": {
-                        "id": 1,
-                        "name": "Starved",
-                        "description": "Equipment starved",
-                    },
-                    "metadata": {
-                        "source": "plc-controller",
-                        "uri": "opc://plc1/DB1.DBW0",
-                        "asset": {
-                            "id": 101,
-                            "name": "Pump-101",
-                            "description": "Centrifugal water pump for cooling system",
-                        },
-                    },
-                },
-            ],
-        },
-        {
-            "elementId": "pump-101-alert",
-            "displayName": "pump-101 Alert",
-            "typeId": "alert-type",
-            "namespaceUri": "https://abelara.com/equipment",
-            "hasChildren": False,
-            "relationships": {
-                "HasParent": ["cesmii-plant1-utilities-watersystem-pumpstation-pump101"],
-            },
-            "values": [
-                {
-                    "timestamp": "2025-10-29T18:24:50.802109+00:00",
-                    "severity": 3,
-                    "code": "TEMP_ALARM",
-                    "message": "Pump bearing temperature above alert threshold",
-                    "metadata": {
-                        "source": "monitoring-system",
-                        "uri": "opc://plc1/DB1.DBD4",
-                        "asset": {
-                            "id": 101,
-                            "name": "Pump-101",
-                            "description": "Centrifugal water pump for cooling system",
-                        },
-                        "acknowledgment": {
-                            "acknowledged": False,
-                            "acknowledgedBy": None,
-                            "acknowledgedAt": None,
-                        },
-                        "additionalInfo": {
-                            "temperature": 106.1,
-                            "warningThreshold": 75.0,
-                            "alarmThreshold": 85.0,
-                            "sensorLocation": "Drive End Bearing",
-                            "trend": "Rising",
-                            "timeInAlarm": 23,
-                            "recommendedAction": "Check alignment",
-                            "priority": "Low",
-                        },
-                    },
-                },
-                {
-                    "timestamp": "2025-10-29T18:26:07.704923+00:00",
-                    "severity": 2,
-                    "code": "TEMP_HIGH",
-                    "message": "Pump bearing temperature exceeds warning threshold",
-                    "metadata": {
-                        "source": "monitoring-system",
-                        "uri": "opc://plc1/DB1.DBD4",
-                        "asset": {
-                            "id": 101,
-                            "name": "Pump-101",
-                            "description": "Centrifugal water pump for cooling system",
-                        },
-                        "acknowledgment": {
-                            "acknowledged": False,
-                            "acknowledgedBy": None,
-                            "acknowledgedAt": None,
-                        },
-                        "additionalInfo": {
-                            "temperature": 78.7,
-                            "warningThreshold": 75.0,
-                            "alarmThreshold": 85.0,
-                            "sensorLocation": "Drive End Bearing",
-                            "trend": "Stable",
-                            "timeInAlarm": 12,
-                            "recommendedAction": "Reduce load",
-                            "priority": "Medium",
-                        },
-                    },
-                },
-                {
-                    "timestamp": "2025-10-29T18:23:28.764138+00:00",
-                    "severity": 1,
-                    "code": "MAINT_DUE",
-                    "message": "Pump maintenance due within 100 hours",
-                    "metadata": {
-                        "source": "monitoring-system",
-                        "uri": "opc://plc1/DB1.DBD4",
-                        "asset": {
-                            "id": 101,
-                            "name": "Pump-101",
-                            "description": "Centrifugal water pump for cooling system",
-                        },
-                        "acknowledgment": {
-                            "acknowledged": False,
-                            "acknowledgedBy": None,
-                            "acknowledgedAt": None,
-                        },
-                        "additionalInfo": {
-                            "temperature": 77.0,
-                            "warningThreshold": 75.0,
-                            "alarmThreshold": 85.0,
-                            "sensorLocation": "Drive End Bearing",
-                            "trend": "Stable",
-                            "timeInAlarm": 21,
-                            "recommendedAction": "Check alignment",
-                            "priority": "Critical",
-                        },
-                    },
-                },
-            ],
-        },
-        {
-            "elementId": "pump-101-product",
-            "displayName": "pump-101 Product",
-            "typeId": "product-type",
-            "namespaceUri": "https://abelara.com/equipment",
-            "hasChildren": False,
-            "relationships": {
-                "HasParent": ["cesmii-plant1-utilities-watersystem-pumpstation-pump101"],
-            },
-            "values": [
-                {
-                    "timestamp": "2025-10-29T18:27:55.457173+00:00",
-                    "id": 1,
-                    "name": "Cooling Water",
-                    "description": "Process cooling water for heat exchange systems",
-                    "idealCycleTime": 3600,
-                    "tolerance": 0.05,
-                    "unit": "m\u00b3/h",
-                    "family": {
-                        "id": 1,
-                        "name": "Utilities",
-                        "description": "Utility products and services",
-                    },
-                    "metadata": {
-                        "source": "product-management",
-                        "uri": "product://cooling-water",
-                        "asset": {
-                            "id": 101,
-                            "name": "Pump-101",
-                            "description": "Centrifugal water pump for cooling system",
-                        },
-                        "additionalInfo": {
-                            "specifications": {
-                                "temperature": "15-25\u00b0C",
-                                "pressure": "3-8 bar",
-                                "quality": "Process Grade",
-                                "chlorinated": True,
+                        "metadata": {
+                            "source": "plc-controller",
+                            "uri": "opc://plc1/DB1.DBW0",
+                            "asset": {
+                                "id": 101,
+                                "name": "Pump-101",
+                                "description": "Centrifugal water pump for cooling system",
                             },
-                            "regulatoryCompliance": [
-                                "ISO 14001",
-                                "Water Quality Standards",
-                            ],
                         },
                     },
-                }
+                    #Values need metadata too, in fact some of the RFC 3.1.2 Object Metadata really belongs at the Value level
+                    "quality": "GOOD",
+                    #Our mock platform implementation was smart enough to lift this metadata from the payload. 
+                    "timestamp": "2025-10-29T18:20:44.779036+00:00",
+                },
+                {
+                    "value": {
+                        "timestamp": "2025-10-28T18:20:44.779036+00:00",
+                        "description": "Pump is in operation",
+                        "color": "#00FF00",
+                        "type": {
+                            "id": 1,
+                            "name": "Operating",
+                            "description": "Equipment operating normally",
+                        },
+                        "metadata": {
+                            "source": "plc-controller",
+                            "uri": "opc://plc1/DB1.DBW0",
+                            "asset": {
+                                "id": 101,
+                                "name": "Pump-101",
+                                "description": "Centrifugal water pump for cooling system",
+                            },
+                        },
+                    },
+                    "quality": "GOOD",
+                    "timestamp": "2025-10-28T18:20:44.779036+00:00",
+                },
+                {
+                    "value": {
+                        "timestamp": "2025-10-27T18:20:44.779036+00:00",
+                        "description": "Pump is in operation",
+                        "color": "#FFFF00",
+                        "type": {
+                            "id": 1,
+                            "name": "Starved",
+                            "description": "Equipment starved",
+                        },
+                        "metadata": {
+                            "source": "plc-controller",
+                            "uri": "opc://plc1/DB1.DBW0",
+                            "asset": {
+                                "id": 101,
+                                "name": "Pump-101",
+                                "description": "Centrifugal water pump for cooling system",
+                            },
+                        },
+                    },
+                    "quality": "GOOD",
+                    "timestamp": "2025-10-27T18:20:44.779036+00:00",
+                },
             ],
         },
         {
             "elementId": "pump-101-production",
             "displayName": "pump-101 Production",
-            "typeId": "production-type",
             "namespaceUri": "https://abelara.com/equipment",
+            "typeId": "production-type",
+            "parentId": "pump-101",
+            #In this case, we set hasChildren false to indicate that a value query should not recurse through the Composition relationship
+            # This is an implementation choice on the part of a platform that limits or expands discoverability
+            # TODO: Discuss with group!
             "hasChildren": False,
             "relationships": {
-                "HasParent": ["cesmii-plant1-utilities-watersystem-pumpstation-pump101"],
+                "HasParent": "pump-101",
+                #Class-composition relationship, shown at the instance level,
+                # This indicates that pump-101-production data is a composition that includes another type of data
+                "ComposedOf": [
+                    "pump-101-production-product",
+                ]
             },
-            "values": [
-                {
-                    "timestamp": "2025-10-29T18:29:53.368598+00:00",
-                    "start_ts": "2025-10-29T18:29:53.368607+00:00",
-                    "end_ts": None,
-                    "counts": [
-                        {
-                            "type": {
-                                "id": 1,
-                                "name": "Water Delivered",
-                                "description": "Total water delivered to cooling system",
-                                "unit": "m\u00b3",
-                            },
-                            "quantity": 320,
-                            "timestamp": "2025-10-29T18:29:53.368610+00:00",
-                        },
-                        {
-                            "type": {
-                                "id": 2,
-                                "name": "Runtime Hours",
-                                "description": "Total pump runtime hours",
-                                "unit": "hours",
-                            },
-                            "quantity": 6.9,
-                            "timestamp": "2025-10-29T18:29:53.368615+00:00",
-                        },
-                    ],
-                    "metadata": {
-                        "source": "production-tracker",
-                        "uri": "production://cooling-system-2024-009",
-                        "asset": {
-                            "id": 101,
-                            "name": "Pump-101",
-                            "description": "Centrifugal water pump for cooling system",
-                        },
-                        "product": {
-                            "id": 1,
-                            "name": "Cooling Water",
-                            "description": "Process cooling water for heat exchange systems",
-                            "idealCycleTime": 3600,
-                            "tolerance": 0.05,
-                            "unit": "m\u00b3/h",
-                            "family": {
-                                "id": 1,
-                                "name": "Utilities",
-                                "description": "Utility products and services",
-                            },
-                        },
-                        "additionalInfo": {
-                            "shift": "Weekend",
-                            "operator": "Bob Wilson",
-                            "demandLevel": "High",
-                            "systemEfficiency": 96.6,
-                            "energyConsumption": 32.3,
-                            "qualityScore": 101.1,
-                            "plannedProduction": 350,
-                            "actualProduction": 320,
-                            "efficiency": 91.4,
-                        },
-                    },
-                }
-            ],
+        },
+        {
+            "elementId": "pump-101-production-product",
+            "displayName": "pump-101 Product",
+            "namespaceUri": "https://abelara.com/equipment",
+            "typeId": "product-type",
+            #This parenthood is through the composition relationship, not a topological hierarchy
+            # The RFC requires this member, but it should be understood in the context of the relationships defined below
+            "parentId": "pump-101-production",
+            "hasChildren": False,
+            "relationships": {
+                # The inclusion of ComposedBy and deliberate ommission of HasParent indicates a graph relationship and labels the edge
+                "ComposedBy": ["pump-101-production"],
+            },
         },
         {
             "elementId": "pump-101-measurements",
             "displayName": "pump-101 Measurements",
-            "typeId": "measurements-type",
             "namespaceUri": "https://abelara.com/equipment",
+            "typeId": "measurements-type",
+            "parentId": "pump-101",
             "hasChildren": True,
             "relationships": {
-                "HasParent": ["cesmii-plant1-utilities-watersystem-pumpstation-pump101"],
+                "HasParent": "pump-101",
                 "HasChildren": [
-                    "pump-101-measurements-bearing-temperature",
-                    "pump-101-measurements-vibration-analysis",
-                    "pump-101-measurements-oil-analysis",
+                    "pump-101-bearing-temperature",
                 ],
             },
         },
         {
             "elementId": "pump-101-bearing-temperature",
             "displayName": "pump-101 Bearing Temperature",
-            "typeId": "measurement-type",
             "namespaceUri": "https://abelara.com/equipment",
-            "hasChildren": False,
+            "typeId": "measurement-type",
+            "parentId": "pump-101-measurements",
+            "hasChildren": True,
             "relationships": {
-                "HasParent": ["pump-101-measurements"],
+                "HasParent": "pump-101-measurements",
+                "HasChildren": ["pump-101-measurements-bearing-temperature-value", "pump-101-measurements-bearing-temperature-health"]
             },
-            "values": [
+            "records": [
                 {
-                    "timestamp": "2025-10-28T18:32:47.673157+00:00",
-                    "type": {
-                        "id": 1,
-                        "name": "Bearing Temperature",
-                        "description": "Precision bearing temperature measurement",
-                    },
-                    "value": 70.34,
-                    "unit": "\u00b0C",
-                    "target": 70.0,
-                    "tolerance": 10.5,
-                    "inTolerance": True,
-                    "metadata": {
-                        "source": "precision-maintenance",
-                        "uri": "maintenance://pump-101/bearing-temperature",
-                        "asset": {
-                            "id": 101,
-                            "name": "Pump-101",
-                            "description": "Centrifugal water pump for cooling system",
-                        },
-                        "additionalInfo": {
-                            "technician": "John Smith",
-                            "measurementMethod": "Oil Sampling",
-                            "equipmentUsed": "Fluke Ti480",
-                            "measurementDate": "2025-10-29T18:32:47.673173+00:00",
-                            "nextMeasurementDue": "2024-06-15",
-                            "trend": "Deteriorating",
-                            "measurementLocation": "Drive End Bearing",
-                        },
-                    },
-                    "product": {
-                        "id": 1,
-                        "name": "Cooling Water",
-                        "description": "Process cooling water",
-                        "family": {
+                    "value": {
+                        "timestamp": "2025-10-29T18:32:47.673157+00:00",
+                        "type": {
                             "id": 1,
-                            "name": "Utilities",
-                            "description": "Utility products and services",
+                            "name": "Bearing Temperature",
+                            "description": "Precision bearing temperature measurement",
+                        },
+                        "value": 70.34,
+                        "health": 12,
+                        "unit": "\u00b0C",
+                        "target": 70.0,
+                        "tolerance": 10.5,
+                        "inTolerance": True,
+                        "metadata": {
+                            "source": "precision-maintenance",
+                            "uri": "maintenance://pump-101/bearing-temperature",
+                            "asset": {
+                                "id": 101,
+                                "name": "Pump-101",
+                                "description": "Centrifugal water pump for cooling system",
+                            },
+                            "additionalInfo": {
+                                "technician": "John Smith",
+                                "measurementMethod": "Oil Sampling",
+                                "equipmentUsed": "Fluke Ti480",
+                                "measurementDate": "2025-10-29T18:32:47.673173+00:00",
+                                "nextMeasurementDue": "2024-06-15",
+                                "trend": "Deteriorating",
+                                "measurementLocation": "Drive End Bearing",
+                            },
+                        },
+                        "product": {
+                            "id": 1,
+                            "name": "Cooling Water",
+                            "description": "Process cooling water",
+                            "family": {
+                                "id": 1,
+                                "name": "Utilities",
+                                "description": "Utility products and services",
+                            },
+                        },
+                        "productionContext": {
+                            "batchId": "MAINT-2024-979",
+                            "processStep": "Precision Maintenance",
+                            "demand": "Emergency",
                         },
                     },
-                    "productionContext": {
-                        "batchId": "MAINT-2024-979",
-                        "processStep": "Precision Maintenance",
-                        "demand": "Emergency",
-                    },
-                },
-                {
+                    "quality": "GOOD",
                     "timestamp": "2025-10-29T18:32:47.673157+00:00",
-                    "type": {
-                        "id": 1,
-                        "name": "Bearing Temperature",
-                        "description": "Precision bearing temperature measurement",
+                },
+                {
+                    "value": {
+                        "timestamp": "2025-10-28T18:32:47.673157+00:00",
+                        "type": {
+                            "id": 1,
+                            "name": "Bearing Temperature",
+                            "description": "Precision bearing temperature measurement",
+                        },
+                        "value": 71.79,
+                        "health": 13,
+                        "unit": "\u00b0C",
+                        "target": 70.0,
+                        "tolerance": 10.5,
+                        "inTolerance": True,
+                        "metadata": {
+                            "source": "precision-maintenance",
+                            "uri": "maintenance://pump-101/bearing-temperature",
+                            "asset": {
+                                "id": 101,
+                                "name": "Pump-101",
+                                "description": "Centrifugal water pump for cooling system",
+                            },
+                            "additionalInfo": {
+                                "technician": "John Smith",
+                                "measurementMethod": "Oil Sampling",
+                                "equipmentUsed": "Fluke Ti480",
+                                "measurementDate": "2025-10-28T18:32:47.673173+00:00",
+                                "nextMeasurementDue": "2024-06-15",
+                                "trend": "Deteriorating",
+                                "measurementLocation": "Drive End Bearing",
+                            },
+                        },
+                        "product": {
+                            "id": 1,
+                            "name": "Cooling Water",
+                            "description": "Process cooling water",
+                            "family": {
+                                "id": 1,
+                                "name": "Utilities",
+                                "description": "Utility products and services",
+                            },
+                        },
+                        "productionContext": {
+                            "batchId": "MAINT-2024-979",
+                            "processStep": "Precision Maintenance",
+                            "demand": "Emergency",
+                        },
                     },
+                    "quality": "GOOD",
+                    "timestamp": "2025-10-28T18:32:47.673157+00:00",
+                },
+            ],
+        },
+        {
+            "elementId": "pump-101-measurements-bearing-temperature-value",
+            "displayName": "Pump 101 Bearing Temperature Value",
+            "namespaceUri": "https://abelara.com/equipment",
+            "typeId": "measurement-value-type",
+            "parentId": "pump-101-bearing-temperature",
+            "hasChildren": False,
+            "relationships": {
+                "HasParent": "pump-101-bearing-temperature"
+            },
+            "records": [
+                {
+                    "value": 70.34,
+                    "quality": "GOOD",
+                    "timestamp": "2025-10-28T18:32:47.673157+00:00"
+                },
+                {
                     "value": 71.79,
-                    "unit": "\u00b0C",
-                    "target": 70.0,
-                    "tolerance": 10.5,
-                    "inTolerance": True,
-                    "metadata": {
-                        "source": "precision-maintenance",
-                        "uri": "maintenance://pump-101/bearing-temperature",
-                        "asset": {
-                            "id": 101,
-                            "name": "Pump-101",
-                            "description": "Centrifugal water pump for cooling system",
-                        },
-                        "additionalInfo": {
-                            "technician": "John Smith",
-                            "measurementMethod": "Oil Sampling",
-                            "equipmentUsed": "Fluke Ti480",
-                            "measurementDate": "2025-10-29T18:32:47.673173+00:00",
-                            "nextMeasurementDue": "2024-06-15",
-                            "trend": "Deteriorating",
-                            "measurementLocation": "Drive End Bearing",
-                        },
-                    },
-                    "product": {
-                        "id": 1,
-                        "name": "Cooling Water",
-                        "description": "Process cooling water",
-                        "family": {
-                            "id": 1,
-                            "name": "Utilities",
-                            "description": "Utility products and services",
-                        },
-                    },
-                    "productionContext": {
-                        "batchId": "MAINT-2024-979",
-                        "processStep": "Precision Maintenance",
-                        "demand": "Emergency",
-                    },
-                },
+                    "quality": "GOOD",
+                    "timestamp": "2025-10-27T18:32:47.673157+00:00"
+                }
             ],
+             # Optional Object Metadata (RFC 3.1.2)
+            "engUnit": "°F",
+            "interpolation": "None"
         },
         {
-            "elementId": "pump-101-vibration-analysis",
-            "displayName": "pump-101 Vibration Analysis",
-            "typeId": "measurement-type",
+            "elementId": "pump-101-measurements-bearing-temperature-health",
+            "displayName": "Pump 101 Bearing Health",
             "namespaceUri": "https://abelara.com/equipment",
+            "typeId": "measurement-health-type",
+            "parentId": "pump-101-bearing-temperature",
             "hasChildren": False,
             "relationships": {
-                "HasParent": ["pump-101-measurements"],
+                "HasParent": "pump-101-bearing-temperature"
             },
-            "values": [
+            "records": [
                 {
-                    "timestamp": "2025-10-29T18:34:55.885390+00:00",
-                    "type": {
-                        "id": 2,
-                        "name": "Vibration Analysis",
-                        "description": "Precision vibration measurement",
-                    },
-                    "value": 1.36,
-                    "unit": "mm/s",
-                    "target": 1.2,
-                    "tolerance": 0.18,
-                    "inTolerance": False,
-                    "metadata": {
-                        "source": "precision-maintenance",
-                        "uri": "maintenance://pump-101/vibration-analysis",
-                        "asset": {
-                            "id": 101,
-                            "name": "Pump-101",
-                            "description": "Centrifugal water pump for cooling system",
-                        },
-                        "additionalInfo": {
-                            "technician": "Mike Johnson",
-                            "measurementMethod": "Laser Alignment",
-                            "equipmentUsed": "Spectro Scientific",
-                            "measurementDate": "2025-10-29T18:34:55.885397+00:00",
-                            "nextMeasurementDue": "2024-06-15",
-                            "trend": "Deteriorating",
-                            "measurementLocation": "Drive End",
-                        },
-                    },
-                    "product": {
-                        "id": 1,
-                        "name": "Cooling Water",
-                        "description": "Process cooling water",
-                        "family": {
-                            "id": 1,
-                            "name": "Utilities",
-                            "description": "Utility products and services",
-                        },
-                    },
-                    "productionContext": {
-                        "batchId": "MAINT-2024-438",
-                        "processStep": "Precision Maintenance",
-                        "demand": "Condition Based",
-                    },
+                    "value": 12,
+                    "quality": "GOOD",
+                    "timestamp": "2025-10-28T18:32:47.673157+00:00"
                 },
                 {
-                    "timestamp": "2025-10-28T18:34:55.885390+00:00",
-                    "type": {
-                        "id": 2,
-                        "name": "Vibration Analysis",
-                        "description": "Precision vibration measurement",
-                    },
-                    "value": 1.75,
-                    "unit": "mm/s",
-                    "target": 1.2,
-                    "tolerance": 0.18,
-                    "inTolerance": False,
-                    "metadata": {
-                        "source": "precision-maintenance",
-                        "uri": "maintenance://pump-101/vibration-analysis",
-                        "asset": {
-                            "id": 101,
-                            "name": "Pump-101",
-                            "description": "Centrifugal water pump for cooling system",
-                        },
-                        "additionalInfo": {
-                            "technician": "Mike Johnson",
-                            "measurementMethod": "Laser Alignment",
-                            "equipmentUsed": "Spectro Scientific",
-                            "measurementDate": "2025-10-29T18:34:55.885397+00:00",
-                            "nextMeasurementDue": "2024-06-15",
-                            "trend": "Deteriorating",
-                            "measurementLocation": "Drive End",
-                        },
-                    },
-                    "product": {
-                        "id": 1,
-                        "name": "Cooling Water",
-                        "description": "Process cooling water",
-                        "family": {
-                            "id": 1,
-                            "name": "Utilities",
-                            "description": "Utility products and services",
-                        },
-                    },
-                    "productionContext": {
-                        "batchId": "MAINT-2024-438",
-                        "processStep": "Precision Maintenance",
-                        "demand": "Condition Based",
-                    },
-                },
-            ],
-            "timestamp": "2025-10-29T10:15:30Z",
-        },
-        {
-            "elementId": "pump-101-oil-analysis",
-            "displayName": "pump-101 Oil Analysis",
-            "typeId": "measurement-type",
-            "namespaceUri": "https://abelara.com/equipment",
-            "hasChildren": False,
-            "relationships": {
-                "HasParent": ["pump-101-measurements"],
-            },
-            "values": [
-                {
-                    "timestamp": "2025-10-29T18:35:42.019884+00:00",
-                    "type": {
-                        "id": 3,
-                        "name": "Oil Analysis",
-                        "description": "Oil quality measurement",
-                    },
-                    "value": 12.41,
-                    "unit": "mg/kg",
-                    "target": 8.0,
-                    "tolerance": 1.2,
-                    "inTolerance": False,
-                    "metadata": {
-                        "source": "precision-maintenance",
-                        "uri": "maintenance://pump-101/oil-analysis",
-                        "asset": {
-                            "id": 101,
-                            "name": "Pump-101",
-                            "description": "Centrifugal water pump for cooling system",
-                        },
-                        "additionalInfo": {
-                            "technician": "Jane Doe",
-                            "measurementMethod": "Infrared Thermography",
-                            "equipmentUsed": "Fluke 1507",
-                            "measurementDate": "2025-10-29T18:35:42.019891+00:00",
-                            "nextMeasurementDue": "2024-06-15",
-                            "trend": "Deteriorating",
-                            "measurementLocation": "Oil Reservoir",
-                        },
-                    },
-                    "product": {
-                        "id": 1,
-                        "name": "Cooling Water",
-                        "description": "Process cooling water",
-                        "family": {
-                            "id": 1,
-                            "name": "Utilities",
-                            "description": "Utility products and services",
-                        },
-                    },
-                    "productionContext": {
-                        "batchId": "MAINT-2024-852",
-                        "processStep": "Precision Maintenance",
-                        "demand": "Emergency",
-                    },
-                },
-                {
-                    "timestamp": "2025-10-28T18:35:42.019884+00:00",
-                    "type": {
-                        "id": 3,
-                        "name": "Oil Analysis",
-                        "description": "Oil quality measurement",
-                    },
-                    "value": 9.35,
-                    "unit": "mg/kg",
-                    "target": 8.0,
-                    "tolerance": 1.2,
-                    "inTolerance": False,
-                    "metadata": {
-                        "source": "precision-maintenance",
-                        "uri": "maintenance://pump-101/oil-analysis",
-                        "asset": {
-                            "id": 101,
-                            "name": "Pump-101",
-                            "description": "Centrifugal water pump for cooling system",
-                        },
-                        "additionalInfo": {
-                            "technician": "Jane Doe",
-                            "measurementMethod": "Infrared Thermography",
-                            "equipmentUsed": "Fluke 1507",
-                            "measurementDate": "2025-10-29T18:35:42.019891+00:00",
-                            "nextMeasurementDue": "2024-06-15",
-                            "trend": "Deteriorating",
-                            "measurementLocation": "Oil Reservoir",
-                        },
-                    },
-                    "product": {
-                        "id": 1,
-                        "name": "Cooling Water",
-                        "description": "Process cooling water",
-                        "family": {
-                            "id": 1,
-                            "name": "Utilities",
-                            "description": "Utility products and services",
-                        },
-                    },
-                    "productionContext": {
-                        "batchId": "MAINT-2024-852",
-                        "processStep": "Precision Maintenance",
-                        "demand": "Emergency",
-                    },
-                },
-                {
-                    "timestamp": "2025-10-27T18:35:42.019884+00:00",
-                    "type": {
-                        "id": 3,
-                        "name": "Oil Analysis",
-                        "description": "Oil quality measurement",
-                    },
-                    "value": 11.77,
-                    "unit": "mg/kg",
-                    "target": 8.0,
-                    "tolerance": 1.2,
-                    "inTolerance": False,
-                    "metadata": {
-                        "source": "precision-maintenance",
-                        "uri": "maintenance://pump-101/oil-analysis",
-                        "asset": {
-                            "id": 101,
-                            "name": "Pump-101",
-                            "description": "Centrifugal water pump for cooling system",
-                        },
-                        "additionalInfo": {
-                            "technician": "Jane Doe",
-                            "measurementMethod": "Infrared Thermography",
-                            "equipmentUsed": "Fluke 1507",
-                            "measurementDate": "2025-10-29T18:35:42.019891+00:00",
-                            "nextMeasurementDue": "2024-06-15",
-                            "trend": "Deteriorating",
-                            "measurementLocation": "Oil Reservoir",
-                        },
-                    },
-                    "product": {
-                        "id": 1,
-                        "name": "Cooling Water",
-                        "description": "Process cooling water",
-                        "family": {
-                            "id": 1,
-                            "name": "Utilities",
-                            "description": "Utility products and services",
-                        },
-                    },
-                    "productionContext": {
-                        "batchId": "MAINT-2024-852",
-                        "processStep": "Precision Maintenance",
-                        "demand": "Emergency",
-                    },
-                },
-            ],
+                    "value": 13,
+                    "quality": "GOOD",
+                    "timestamp": "2025-10-27T18:32:47.673157+00:00"
+                }
+            ]
         },
         {
             "elementId": "tank-201",
             "displayName": "tank-201",
-            "typeId": "work-unit-type",
-            "hasChildren": True,
             "namespaceUri": "https://isa.org/isa95",
+            "typeId": "work-unit-type",
+            "parentId": "/",
+            "hasChildren": False,
             "relationships": {
-                "HasParent": ["cesmii-plant1-utilities-watersystem"],
-                "HasChildren": ["tank-201-machine-id", "tank-201-state"],
                 "SuppliedBy": "pump-101",
                 "MonitoredBy": "sensor-001",
             },
         },
         {
-            "elementId": "tank-201-state",
-            "displayName": "tank-201 State",
-            "typeId": "state-type",
-            "namespaceUri": "https://abelara.com/equipment",
-            "hasChildren": False,
-            "relationships": {
-                "HasParent": ["tank-201"],
-            },
-            "values": [
-                {
-                    "timestamp": "2025-10-29T18:42:41.516253+00:00",
-                    "description": "Tank is maintenance",
-                    "color": "#800080",
-                    "type": {
-                        "id": 5,
-                        "name": "Maintenance",
-                        "description": "Tank under maintenance",
-                    },
-                    "metadata": {
-                        "source": "plc-controller",
-                        "uri": "opc://plc1/DB1.DBW10",
-                        "asset": {
-                            "id": 201,
-                            "name": "Tank-201",
-                            "description": "Raw water storage tank for process supply",
-                        },
-                        "previousState": {
-                            "id": 2,
-                            "name": "Full",
-                            "description": "Tank is full",
-                            "color": "#228B22",
-                            "type": {
-                                "id": 2,
-                                "name": "Full",
-                                "description": "Tank is full",
-                            },
-                        },
-                        "additionalInfo": {
-                            "runTime": 562,
-                            "lastFillTime": "2025-10-29T18:42:41.516272+00:00",
-                            "mode": "MANUAL",
-                            "operator": "Eva Green",
-                        },
-                    },
-                },
-                {
-                    "timestamp": "2025-10-28T18:43:01.789262+00:00",
-                    "description": "Tank is filling",
-                    "color": "#00BFFF",
-                    "type": {
-                        "id": 1,
-                        "name": "Filling",
-                        "description": "Tank is being filled",
-                    },
-                    "metadata": {
-                        "source": "plc-controller",
-                        "uri": "opc://plc1/DB1.DBW10",
-                        "asset": {
-                            "id": 201,
-                            "name": "Tank-201",
-                            "description": "Raw water storage tank for process supply",
-                        },
-                        "previousState": {
-                            "id": 3,
-                            "name": "Emptying",
-                            "description": "Tank is being emptied",
-                            "color": "#FFD700",
-                            "type": {
-                                "id": 3,
-                                "name": "Emptying",
-                                "description": "Tank is being emptied",
-                            },
-                        },
-                        "additionalInfo": {
-                            "runTime": 2669,
-                            "lastFillTime": "2025-10-29T18:43:01.789282+00:00",
-                            "mode": "MANUAL",
-                            "operator": "Tom Lee",
-                        },
-                    },
-                },
-                {
-                    "timestamp": "2025-10-27T18:43:27.125067+00:00",
-                    "description": "Tank is filling",
-                    "color": "#00BFFF",
-                    "type": {
-                        "id": 1,
-                        "name": "Filling",
-                        "description": "Tank is being filled",
-                    },
-                    "metadata": {
-                        "source": "plc-controller",
-                        "uri": "opc://plc1/DB1.DBW10",
-                        "asset": {
-                            "id": 201,
-                            "name": "Tank-201",
-                            "description": "Raw water storage tank for process supply",
-                        },
-                        "previousState": {
-                            "id": 5,
-                            "name": "Maintenance",
-                            "description": "Tank under maintenance",
-                            "color": "#800080",
-                            "type": {
-                                "id": 5,
-                                "name": "Maintenance",
-                                "description": "Tank under maintenance",
-                            },
-                        },
-                        "additionalInfo": {
-                            "runTime": 664,
-                            "lastFillTime": "2025-10-29T18:43:27.125086+00:00",
-                            "mode": "AUTO",
-                            "operator": "Alice Brown",
-                        },
-                    },
-                },
-                {
-                    "timestamp": "2025-10-26T18:43:42.345524+00:00",
-                    "description": "Tank is low level",
-                    "color": "#FF4500",
-                    "type": {
-                        "id": 4,
-                        "name": "Low Level",
-                        "description": "Tank water level is low",
-                    },
-                    "metadata": {
-                        "source": "plc-controller",
-                        "uri": "opc://plc1/DB1.DBW10",
-                        "asset": {
-                            "id": 201,
-                            "name": "Tank-201",
-                            "description": "Raw water storage tank for process supply",
-                        },
-                        "previousState": {
-                            "id": 3,
-                            "name": "Emptying",
-                            "description": "Tank is being emptied",
-                            "color": "#FFD700",
-                            "type": {
-                                "id": 3,
-                                "name": "Emptying",
-                                "description": "Tank is being emptied",
-                            },
-                        },
-                        "additionalInfo": {
-                            "runTime": 1948,
-                            "lastFillTime": "2025-10-29T18:43:42.345542+00:00",
-                            "mode": "MANUAL",
-                            "operator": "Eva Green",
-                        },
-                    },
-                },
-            ],
-        },
-        {
-            "elementId": "tank-201-alert",
-            "displayName": "tank-201 Alert",
-            "typeId": "alert-type",
-            "namespaceUri": "https://abelara.com/equipment",
-            "hasChildren": False,
-            "relationships": {
-                "HasParent": ["tank-201"],
-            },
-            "values": [
-                {
-                    "timestamp": "2025-10-29T18:44:17.833121+00:00",
-                    "severity": 2,
-                    "code": "LEVEL_LOW",
-                    "message": "Tank water level below minimum threshold",
-                    "metadata": {
-                        "source": "monitoring-system",
-                        "uri": "opc://plc1/DB1.DBD44",
-                        "asset": {
-                            "id": 201,
-                            "name": "Tank-201",
-                            "description": "Raw water storage tank for process supply",
-                        },
-                        "acknowledgment": {
-                            "acknowledged": False,
-                            "acknowledgedBy": None,
-                            "acknowledgedAt": None,
-                        },
-                        "additionalInfo": {
-                            "waterLevel": 3.84,
-                            "minThreshold": 1.0,
-                            "maxThreshold": 5.0,
-                            "sensorLocation": "Tank Center",
-                            "trend": "Falling",
-                            "timeInAlarm": 4,
-                            "recommendedAction": "Schedule maintenance",
-                            "priority": "Critical",
-                        },
-                    },
-                },
-                {
-                    "timestamp": "2025-10-28T18:44:38.104100+00:00",
-                    "severity": 3,
-                    "code": "QUALITY_ALARM",
-                    "message": "Water quality exceeds alarm threshold",
-                    "metadata": {
-                        "source": "monitoring-system",
-                        "uri": "opc://plc1/DB1.DBD44",
-                        "asset": {
-                            "id": 201,
-                            "name": "Tank-201",
-                            "description": "Raw water storage tank for process supply",
-                        },
-                        "acknowledgment": {
-                            "acknowledged": True,
-                            "acknowledgedBy": "Tom Lee",
-                            "acknowledgedAt": "2025-10-29T18:44:38.104091+00:00",
-                        },
-                        "additionalInfo": {
-                            "waterLevel": 3.74,
-                            "minThreshold": 1.0,
-                            "maxThreshold": 5.0,
-                            "sensorLocation": "Tank Center",
-                            "trend": "Rising",
-                            "timeInAlarm": 8,
-                            "recommendedAction": "Monitor",
-                            "priority": "Low",
-                        },
-                    },
-                },
-                {
-                    "timestamp": "2025-10-29T18:44:53.320437+00:00",
-                    "severity": 3,
-                    "code": "LEVEL_HIGH",
-                    "message": "Tank water level exceeds maximum threshold",
-                    "metadata": {
-                        "source": "monitoring-system",
-                        "uri": "opc://plc1/DB1.DBD44",
-                        "asset": {
-                            "id": 201,
-                            "name": "Tank-201",
-                            "description": "Raw water storage tank for process supply",
-                        },
-                        "acknowledgment": {
-                            "acknowledged": False,
-                            "acknowledgedBy": None,
-                            "acknowledgedAt": None,
-                        },
-                        "additionalInfo": {
-                            "waterLevel": 3.78,
-                            "minThreshold": 1.0,
-                            "maxThreshold": 5.0,
-                            "sensorLocation": "Tank Center",
-                            "trend": "Stable",
-                            "timeInAlarm": 5,
-                            "recommendedAction": "Check sensors",
-                            "priority": "High",
-                        },
-                    },
-                },
-            ],
-        },
-        {
             "elementId": "sensor-001",
             "displayName": "TempSensor-101",
-            "typeId": "sensor-type",
-            "parentId": "cesmii-plant1-utilities-watersystem",
-            "hasChildren": False,
             "namespaceUri": "https://thinkiq.com/equipment",
-            "relationships": {"Monitors": ["tank-201"]},
-            "values": [
+            "typeId": "sensor-type",
+            "parentId": "/",
+            "hasChildren": False,
+            "relationships": {
+                "Monitors": "tank-201"
+            },
+            "records": [
                 {
-                    "Value": 65.4,
-                    "Quality": "GOOD",
-                    "Timestamp": "2025-10-29T10:15:30Z",
-                    "EngUnit": "CEL",
-                    "calibrationDate": "2025-01-15",
+                    "value": 67.1,
+                    # Should these be specified (at least as optional)?
+                    "quality": "GOOD",
+                    "timestamp": "2025-10-28T10:15:30Z",
+                    # Extra value-specific metadata may originate in the publisher's payload and is allowable
+                    "localTimestamp": "2025-01-28T07:15:30-03:00",
                 },
                 {
-                    "Value": 67.1,
-                    "Quality": "GOOD",
-                    "Timestamp": "2025-10-28T10:15:30Z",
-                    "EngUnit": "CEL",
-                    "calibrationDate": "2025-01-15",
+                    "value": 54.9,
+                    "quality": "GOOD",
+                    "timestamp": "2025-10-27T10:15:30Z",
+                    "localTimestamp": "2025-01-27T07:15:30-03:00",
                 },
                 {
-                    "Value": 54.9,
-                    "Quality": "GOOD",
-                    "Timestamp": "2025-10-27T10:15:30Z",
-                    "EngUnit": "CEL",
-                    "calibrationDate": "2025-01-15",
-                },
-                {
-                    "Value": 68.2,
-                    "Quality": "GOOD",
-                    "Timestamp": "2025-10-26T10:15:30Z",
-                    "EngUnit": "CEL",
-                    "calibrationDate": "2025-01-15",
+                    "value": 68.2,
+                    "quality": "GOOD",
+                    "timestamp": "2025-10-26T10:15:30Z",
+                    "localTimestamp": "2025-01-26T07:15:30-03:00",
                 },
             ],
+            # Optional Object Metadata (RFC 3.1.2)
+            "engUnit": "CEL",
+            "calibrationDate": "2025-01-15",
         },
     ],
     "relationshipTypes": [
         {
-            "elementId": "hierarchical-relationship-type",
-            "displayName": "ParentChild",
+            "elementId": "HasParent",
+            "displayName": "HasParent",
             "namespaceUri": "https://cesmii.org/i3x",
-            "directions": [
-                {
-                    "Subject": "HasChildren",
-                    "Target": "HasParent",
-                    "Cardinality": "1:0..1",
-                },
-                {
-                    "Subject": "HasParent",
-                    "Target": "HasChildren",
-                    "Cardinality": "1..*:1",
-                },
-            ],
+            "reverseOf": "HasChildren",
         },
         {
-            "elementId": "inheritance-relationship-type",
-            "displayName": "Inheritance",
+            "elementId": "HasChildren",
+            "displayName": "HasChildren",
             "namespaceUri": "https://cesmii.org/i3x",
-            "directions": [
-                {
-                    "Subject": "InheritedBy",
-                    "Target": "Inherits",
-                    "Cardinality": "1:0..1",
-                },
-                {
-                    "Subject": "InheritedFrom",
-                    "Target": "InheritedBy",
-                    "Cardinality": "1..*:1",
-                },
-            ],
+            "reverseOf": "HasParent"
         },
         {
-            "elementId": "implementation-relationship-type",
-            "displayName": "Implements",
+            "elementId": "InheritedBy",
+            "displayName": "InheritedBy",
             "namespaceUri": "https://cesmii.org/i3x",
-            "directions": [
-                {
-                    "Subject": "ImplementedBy",
-                    "Target": "Implements",
-                    "Cardinality": "1:0..1",
-                },
-                {
-                    "Subject": "ImplementedFrom",
-                    "Target": "ImplementedBy",
-                    "Cardinality": "1..*:1",
-                },
-            ],
+            "reverseOf": "InheritsFrom"
         },
         {
-            "elementId": "dependency-relationship-type",
-            "displayName": "Dependency",
+            "elementId": "InheritsFrom",
+            "displayName": "InheritsFrom",
             "namespaceUri": "https://cesmii.org/i3x",
-            "directions": [
-                {
-                    "Subject": "DependedOnBy",
-                    "Target": "DependsOn",
-                    "Cardinality": "1:0..1",
-                },
-                {
-                    "Subject": "DependsOn",
-                    "Target": "DependedOnBy",
-                    "Cardinality": "1..*:1",
-                },
-            ],
+            "reverseOf": "InheritedBy"
         },
         {
-            "elementId": "aggregation-relationship-type",
-            "displayName": "Aggregates",
+            "elementId": "ComposedOf",
+            "displayName": "ComposedOf",
             "namespaceUri": "https://cesmii.org/i3x",
-            "directions": [
-                {
-                    "Subject": "AggregatedBy",
-                    "Target": "Aggregates",
-                    "Cardinality": "1:0..1",
-                },
-                {
-                    "Subject": "Aggregates",
-                    "Target": "AggregatedBy",
-                    "Cardinality": "1..*:1",
-                },
-            ],
+            "reverseOf": "ComposedBy"
         },
         {
-            "elementId": "supply-relationship-type",
-            "displayName": "Supply",
+            "elementId": "ComposedBy",
+            "displayName": "ComposedBy",
+            "namespaceUri": "https://cesmii.org/i3x",
+            "reverseOf": "ComposedOf"
+        },
+        {
+            "elementId": "Monitors",
+            "displayName": "Monitors",
             "namespaceUri": "https://thinkiq.com/equipment",
-            "directions": [
-                {
-                    "Subject": "SuppliesTo",
-                    "Target": "SuppliedBy",
-                    "Cardinality": "1..*:1..*",
-                },
-                {
-                    "Subject": "SuppliedBy",
-                    "Target": "SuppliesTo",
-                    "Cardinality": "1..*:1..*",
-                },
-            ],
+            "reverseOf": "MonitoredBy"
         },
         {
-            "elementId": "monitoring-relationship-type",
-            "displayName": "Monitoring",
+            "elementId": "MonitoredBy",
+            "displayName": "MonitoredBy",
             "namespaceUri": "https://thinkiq.com/equipment",
-            "directions": [
-                {
-                    "Subject": "Monitors",
-                    "Target": "MonitoredBy",
-                    "Cardinality": "1..*:1..*",
-                },
-                {
-                    "Subject": "MonitoredBy",
-                    "Target": "Monitors",
-                    "Cardinality": "1..*:1..*",
-                },
-            ],
+            "reverseOf": "Monitors"
+        },
+        {
+            "elementId": "SuppliesTo",
+            "displayName": "SuppliesTo",
+            "namespaceUri": "https://thinkiq.com/equipment",
+            "reverseOf": "SuppliedBy"
+        },
+        {
+            "elementId": "SuppliedBy",
+            "displayName": "SuppliedBy",
+            "namespaceUri": "https://thinkiq.com/equipment",
+            "reverseOf": "SuppliesTo"
         },
     ],
 }

--- a/prototypes/python3/server/data_sources/mock/mock_data_source.py
+++ b/prototypes/python3/server/data_sources/mock/mock_data_source.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 from typing import List, Optional, Dict, Any, Callable
+import json
+import os
 from ..data_interface import I3XDataSource
 from .mock_data import I3X_DATA
 from .mock_updater import MockDataUpdater
@@ -12,6 +14,64 @@ class MockDataSource(I3XDataSource):
         self.data = I3X_DATA
         self.updater = MockDataUpdater(self)
         self.update_callback = None
+        # Cache for loaded schema files
+        self._schema_cache = {}
+
+    def _load_schema_definition(self, type_definition: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Load the full type definition from the schema file referenced in type_definition.
+
+        Args:
+            type_definition: Dict with elementId, displayName, namespaceUri, and schema pointer
+
+        Returns:
+            Complete type definition with schema pointer replaced by actual schema dict
+        """
+        schema_pointer = type_definition.get("schema", "")
+        if not schema_pointer:
+            # If no schema pointer, return metadata as-is
+            return type_definition
+
+        # If schema is already a dict (not a string pointer), return as-is
+        if isinstance(schema_pointer, dict):
+            return type_definition
+
+        # Parse schema pointer: "Namespaces/abelara.json#types/state-type"
+        if "#" not in schema_pointer:
+            return type_definition
+
+        file_path, json_pointer = schema_pointer.split("#", 1)
+
+        # Load schema file (with caching)
+        if file_path not in self._schema_cache:
+            # Construct full path relative to this file's directory
+            current_dir = os.path.dirname(os.path.abspath(__file__))
+            full_path = os.path.join(current_dir, file_path)
+
+            try:
+                with open(full_path, 'r') as f:
+                    self._schema_cache[file_path] = json.load(f)
+            except Exception as e:
+                print(f"Error loading schema file {full_path}: {e}")
+                return type_definition
+
+        schema_data = self._schema_cache[file_path]
+
+        # Navigate JSON pointer: "types/state-type" -> schema_data["types"]["state-type"]
+        pointer_parts = json_pointer.strip("/").split("/")
+        current = schema_data
+        for part in pointer_parts:
+            if isinstance(current, dict) and part in current:
+                current = current[part]
+            else:
+                print(f"Could not resolve JSON pointer {json_pointer} in {file_path}")
+                return type_definition
+
+        # Replace the schema pointer string with the actual schema definition
+        result = type_definition.copy()
+        result["schema"] = current
+
+        return result
 
     def start(
         self, update_callback: Optional[Callable[[Dict[str, Any]], None]] = None
@@ -30,18 +90,29 @@ class MockDataSource(I3XDataSource):
     def get_object_types(
         self, namespace_uri: Optional[str] = None
     ) -> List[Dict[str, Any]]:
+        # Filter by namespace if specified
+        type_definition_list = self.data["objectTypes"]
         if namespace_uri:
-            return [
+            type_definition_list = [
                 t
-                for t in self.data["objectTypes"]
+                for t in type_definition_list
                 if t["namespaceUri"] == namespace_uri
             ]
-        return self.data["objectTypes"]
+
+        # Load full schema definitions for each type
+        result = []
+        for type_definition in type_definition_list:
+            full_type_def = self._load_schema_definition(type_definition)
+            result.append(full_type_def)
+
+        return result
 
     def get_object_type_by_id(self, element_id: str) -> Optional[Dict[str, Any]]:
-        for obj_type in self.data["objectTypes"]:
-            if obj_type["elementId"] == element_id:
-                return obj_type
+        # Find the type metadata
+        for type_definition in self.data["objectTypes"]:
+            if type_definition["elementId"] == element_id:
+                # Load and return the full schema definition
+                return self._load_schema_definition(type_definition)
         return None
 
     def get_relationship_types(
@@ -72,10 +143,10 @@ class MockDataSource(I3XDataSource):
         else:
             results = instances
 
-        # Filter out Values member from each instance before returning (unique to mock data)
+        # Filter out records member from each instance before returning (unique to mock data)
         filtered_results = []
         for instance in results:
-            filtered_instance = {k: v for k, v in instance.items() if k != "values"}
+            filtered_instance = {k: v for k, v in instance.items() if k != "records"}
             filtered_results.append(filtered_instance)
 
         return filtered_results
@@ -85,20 +156,22 @@ class MockDataSource(I3XDataSource):
         element_id: str,
         startTime: Optional[str] = None,
         endTime: Optional[str] = None,
+        includeMetadata: bool = False,
+        returnHistory: bool = False,
     ):
         instance = self.get_instance_by_id(element_id, values=True)
 
         if not instance:
             return None
 
-        # Get the Values array
-        values_array = instance.get("values")
+        # Get the records array
+        records_array = instance.get("records")
 
-        # If no Values or Values is not a list, return as is
-        if not values_array or not isinstance(values_array, list):
+        # If no records or records is not a list, return as is
+        if not records_array or not isinstance(records_array, list):
             return None
 
-        returned_value = None
+        returned_records = None
 
         # Filter based on time range
         if startTime and endTime:
@@ -106,48 +179,53 @@ class MockDataSource(I3XDataSource):
             start_dt = datetime.fromisoformat(startTime.replace("Z", "+00:00"))
             end_dt = datetime.fromisoformat(endTime.replace("Z", "+00:00"))
 
-            # Filter Values array to only include items within time range
-            filtered_values = []
-            for value_item in values_array:
-                # Check for both "timestamp" and "Timestamp" (case-insensitive)
-                timestamp_key = None
-                for key in ["timestamp", "Timestamp"]:
-                    if key in value_item:
-                        timestamp_key = key
-                        break
-
-                if timestamp_key:
+            # Filter records array to only include items within time range
+            filtered_records = []
+            for record in records_array:
+                # Each record now has a standard structure with timestamp at the record level
+                if "timestamp" in record:
                     value_dt = datetime.fromisoformat(
-                        value_item[timestamp_key].replace("Z", "+00:00")
+                        record["timestamp"].replace("Z", "+00:00")
                     )
                     if start_dt <= value_dt <= end_dt:
-                        filtered_values.append(value_item)
+                        filtered_records.append(record)
 
-            returned_value = filtered_values
+            returned_records = filtered_records
         else:
-            # No time range specified - return only the most recent value based on timestamp
-            most_recent = None
-            most_recent_dt = None
+            # No time range specified
+            if returnHistory:
+                # Return all historical values for /history endpoint
+                returned_records = records_array
+            else:
+                # Return only most recent value for /value endpoint
+                most_recent = None
+                most_recent_dt = None
 
-            for value_item in values_array:
-                # Check for both "timestamp" and "Timestamp" (case-insensitive)
-                timestamp_key = None
-                for key in ["timestamp", "Timestamp"]:
-                    if key in value_item:
-                        timestamp_key = key
-                        break
+                for record in records_array:
+                    if "timestamp" in record:
+                        value_dt = datetime.fromisoformat(
+                            record["timestamp"].replace("Z", "+00:00")
+                        )
+                        if most_recent_dt is None or value_dt > most_recent_dt:
+                            most_recent_dt = value_dt
+                            most_recent = record
 
-                if timestamp_key:
-                    value_dt = datetime.fromisoformat(
-                        value_item[timestamp_key].replace("Z", "+00:00")
-                    )
-                    if most_recent_dt is None or value_dt > most_recent_dt:
-                        most_recent_dt = value_dt
-                        most_recent = value_item
+                returned_records = most_recent
 
-            returned_value = most_recent
-
-        return returned_value
+        # Process based on includeMetadata flag
+        if not includeMetadata:
+            # Return only the value field(s), not the metadata
+            if isinstance(returned_records, list):
+                # For historical values (list), extract value from each record
+                return [record.get("value") for record in returned_records if "value" in record]
+            elif isinstance(returned_records, dict) and "value" in returned_records:
+                # For single value, extract just the value field
+                return returned_records["value"]
+            else:
+                return returned_records
+        else:
+            # Return full record(s) with metadata (value, quality, timestamp)
+            return returned_records
 
     def get_instance_by_id(
         self, element_id: str, values: bool = False
@@ -155,18 +233,18 @@ class MockDataSource(I3XDataSource):
         for instance in self.data["instances"]:
             if instance["elementId"] == element_id:
                 if values:
-                    # Return instance with Values included
+                    # Return instance with records included
                     return instance
                 else:
-                    # Filter out Values member from each instance before returning (unique to mock data)
+                    # Filter out records member from each instance before returning (unique to mock data)
                     filtered_instance = {
-                        k: v for k, v in instance.items() if k != "values"
+                        k: v for k, v in instance.items() if k != "records"
                     }
                     return filtered_instance
         return None
 
     def get_related_instances(
-        self, element_id: str, relationship_type: str
+        self, element_id: str, relationship_type: Optional[str] = None
     ) -> List[Dict[str, Any]]:
         related_objects = []
 
@@ -183,37 +261,52 @@ class MockDataSource(I3XDataSource):
         # Check if instance has explicit relationship metadata
         relationships_metadata = source_instance.get("relationships", {})
 
-        # Look for the relationship type (case-insensitive match)
-        matching_key = None
-        for key in relationships_metadata.keys():
-            if key.lower() == relationship_type.lower():
-                matching_key = key
-                break
+        # If no relationship_type specified, return all related instances
+        if relationship_type is None:
+            # Collect all related IDs from all relationships
+            all_related_ids = set()
+            for rel_type, related_ids in relationships_metadata.items():
+                if isinstance(related_ids, list):
+                    all_related_ids.update(related_ids)
+                elif isinstance(related_ids, str):
+                    all_related_ids.add(related_ids)
 
-        if matching_key:
-            # Return instances based on explicit relationship declarations
-            related_ids = relationships_metadata[matching_key]
-            if isinstance(related_ids, list):
-                # Get instances directly from data for list of IDs
-                related_objects = [
-                    i for i in self.data["instances"] if i["elementId"] in related_ids
-                ]
-            else:
-                # Handle single ID case - get directly from data
-                for instance in self.data["instances"]:
-                    if instance["elementId"] == related_ids:
-                        related_objects = [instance]
-                        break
-        # Fallback: Handle non-hierarchical relationships dynamically
+            # Get all related instances
+            related_objects = [
+                i for i in self.data["instances"] if i["elementId"] in all_related_ids
+            ]
         else:
-            related_objects = self._process_non_hierarchical_relations(
-                element_id, relationship_type.lower()
-            )
+            # Look for the specific relationship type (case-insensitive match)
+            matching_key = None
+            for key in relationships_metadata.keys():
+                if key.lower() == relationship_type.lower():
+                    matching_key = key
+                    break
 
-        # Filter out Values member from each instance before returning (unique to mock data)
+            if matching_key:
+                # Return instances based on explicit relationship declarations
+                related_ids = relationships_metadata[matching_key]
+                if isinstance(related_ids, list):
+                    # Get instances directly from data for list of IDs
+                    related_objects = [
+                        i for i in self.data["instances"] if i["elementId"] in related_ids
+                    ]
+                else:
+                    # Handle single ID case - get directly from data
+                    for instance in self.data["instances"]:
+                        if instance["elementId"] == related_ids:
+                            related_objects = [instance]
+                            break
+            # Fallback: Handle non-hierarchical relationships dynamically
+            else:
+                related_objects = self._process_non_hierarchical_relations(
+                    element_id, relationship_type.lower()
+                )
+
+        # Filter out records member from each instance before returning (unique to mock data)
         filtered_results = []
         for instance in related_objects:
-            filtered_instance = {k: v for k, v in instance.items() if k != "values"}
+            filtered_instance = {k: v for k, v in instance.items() if k != "records"}
             filtered_results.append(filtered_instance)
 
         return filtered_results
@@ -250,19 +343,51 @@ class MockDataSource(I3XDataSource):
 
             try:
                 # Validate the write schema matches the instance schema
+                # Now records have structure: {value: {...}, quality: "...", timestamp: "..."}
+                current_value = instance["records"][0]["value"]
                 value_schema = self._get_schema(value)
-                instance_schema = self._get_schema(instance["values"][0])
+                instance_schema = self._get_schema(current_value)
 
                 print(f"Value schema: {value_schema}")
                 print(f"Instance schema: {instance_schema}")
 
+                # Try to coerce value to match instance schema for primitive types
+                coerced_value = value
                 if value_schema != instance_schema:
-                    raise Exception("Value schema does not match instance schema")
+                    # Attempt type coercion for numeric types
+                    if instance_schema == "int" and value_schema in ["str", "float"]:
+                        try:
+                            coerced_value = int(float(value))
+                            print(f"Coerced {value} ({value_schema}) to int")
+                        except (ValueError, TypeError):
+                            raise Exception(f"Cannot coerce value to int: {value}")
+                    elif instance_schema == "float" and value_schema in ["str", "int"]:
+                        try:
+                            coerced_value = float(value)
+                            print(f"Coerced {value} ({value_schema}) to float")
+                        except (ValueError, TypeError):
+                            raise Exception(f"Cannot coerce value to float: {value}")
+                    elif instance_schema == "str" and value_schema in ["int", "float"]:
+                        coerced_value = str(value)
+                        print(f"Coerced {value} ({value_schema}) to str")
+                    else:
+                        raise Exception(f"Value schema ({value_schema}) does not match instance schema ({instance_schema})")
 
-                instance["values"][0] = value
-                instance["timestamp"] = datetime.now(timezone.utc).strftime(
+                # Update the value and timestamp in the record
+                current_timestamp = datetime.now(timezone.utc).strftime(
                     "%Y-%m-%dT%H:%M:%SZ"
                 )
+                instance["records"][0]["value"] = coerced_value
+                instance["records"][0]["timestamp"] = current_timestamp
+
+                # Also update timestamp inside value if it exists
+                if isinstance(coerced_value, dict):
+                    if "Timestamp" in coerced_value:
+                        instance["records"][0]["value"]["Timestamp"] = current_timestamp
+                    elif "timestamp" in coerced_value:
+                        instance["records"][0]["value"]["timestamp"] = current_timestamp
+
+                instance["timestamp"] = current_timestamp
 
                 results.append(
                     {

--- a/prototypes/python3/server/models.py
+++ b/prototypes/python3/server/models.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.responses import StreamingResponse
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict
 from typing import Optional, List, Dict, Any, Union, Callable
 from datetime import datetime
 from enum import Enum
@@ -36,9 +36,7 @@ class RelationshipType(BaseModel):
     )
     displayName: str = Field(..., description="Relationship type name")
     namespaceUri: str = Field(..., description="Namespace URI")
-    directions: List[RelationshipTypeDirection] = Field(
-        ..., description="Relationship directions and cardinality"
-    )
+    reverseOf: str = Field(..., description="Type name of reverse relationship")
 
 
 # RFC 3.1.1 - Required Object Metadata (Minimal Instance)
@@ -161,10 +159,12 @@ class RegisterMonitoredItemsRequest(BaseModel):
 
 
 class SyncResponseItem(BaseModel):
+    model_config = ConfigDict(extra='allow')  # Allow extra fields from record metadata
+
     elementId: str
     value: Any
-    timestamp: str
-    dataType: str = "object"
+    timestamp: Optional[str] = None
+    quality: Optional[str] = None
 
 
 class UnsubscribeRequest(BaseModel):

--- a/prototypes/python3/server/routers/objects.py
+++ b/prototypes/python3/server/routers/objects.py
@@ -76,16 +76,17 @@ def get_last_known_value(
 ):
     """Return last known value for an Object"""
     elementId = unquote(elementId)
-    
+
     # Lookup instance to verify it exists
     instance = data_source.get_instance_by_id(elementId)
     if not instance:
         raise HTTPException(status_code=404, detail=f"Element '{elementId}' not found")
 
-    # Get the value. Some objects may not have a value
-    value = data_source.get_instance_values_by_id(elementId)
+    # Get the most recent value with or without metadata based on includeMetadata flag
+    # returnHistory=False ensures only the most recent value is returned
+    value = data_source.get_instance_values_by_id(elementId, includeMetadata=includeMetadata, returnHistory=False)
 
-    return getValue(value, includeMetadata)
+    return value
 
 # 4.2.2.1 Object Element LastKnownValue
 @update.put("/objects/{elementId}/value", summary="Update Value of Object")
@@ -110,23 +111,17 @@ def get_historical_values(
 ):
     """Get the historical values for one or more Objects"""
     elementId = unquote(elementId)
-    
+
      # Lookup instance to verify it exists
     instance = data_source.get_instance_by_id(elementId)
     if not instance:
         raise HTTPException(status_code=404, detail=f"Element '{elementId}' not found")
 
-    # Mock historical data - in real implementation this would query historical store
-    historical_values = data_source.get_instance_values_by_id(elementId, startTime, endTime)
+    # Get historical data with or without metadata based on includeMetadata flag
+    # returnHistory=True ensures all values are returned when no time range is specified
+    historical_values = data_source.get_instance_values_by_id(elementId, startTime, endTime, includeMetadata, returnHistory=True)
 
-    if not isinstance(historical_values, list):
-        historical_values = [historical_values]
-
-    if not includeMetadata:
-        return historical_values
-
-    metadata_array = [getValue(val, includeMetadata) for val in historical_values]
-    return metadata_array
+    return historical_values
 
 # RFC 4.2.2.2 - Object Element HistoricalValue
 @update.put("/objects/{elementId}/history", summary="Update Historical Values of Object")

--- a/prototypes/python3/server/routers/utils.py
+++ b/prototypes/python3/server/routers/utils.py
@@ -39,13 +39,34 @@ def getValueMetadata(value: Any) -> Any:
     }
     return metadata
 
-def getSubscriptionValue(instance: Any, value: Any, includeMetadata: bool) -> Any:
-    """Helper to get subscription value formatted with or without metadata"""
+def getSubscriptionValue(instance: Any, record: Any, includeMetadata: bool) -> Any:
+    """
+    Helper to get subscription value formatted with or without metadata.
+
+    Args:
+        instance: The instance object with elementId
+        record: The record object with structure {value: ..., quality: ..., timestamp: ..., localTimestamp: ..., etc}
+        includeMetadata: If True, include all record-level metadata fields; if False, only include value
+
+    Returns:
+        Dictionary with elementId and value, optionally with all record-level metadata fields
+    """
+    # Extract the actual value from the record structure
+    # The value itself may be a primitive (67.1) or a complex object with its own fields
+    actual_value = record.get("value") if isinstance(record, dict) else record
+
+    # Start with elementId and value (value contains all its data, primitive or complex)
     updateValue = {
         "elementId": instance["elementId"],
-        **getValueMetadata(value),
-        "value": value
+        "value": actual_value
     }
+
+    # If includeMetadata is True, add ALL record-level metadata fields
+    if includeMetadata and isinstance(record, dict):
+        # Add all fields from the record except "value" (which is already included)
+        for key, val in record.items():
+            if key != "value":
+                updateValue[key] = val
 
     return updateValue
 


### PR DESCRIPTION
**Summary**

  Major refactoring of the mock data source to implement a standardized record structure with proper metadata
  handling, improve type schema loading, and fix subscription value updates. In order to accomplish this consistently, and to reduce cognitive load in keeping the mock model in mind, the mock data has been simplified to model a system that looks like this:

<img width="776" height="493" alt="SampleModel" src="https://github.com/user-attachments/assets/3b12e2d3-3c5b-42e3-8a42-404c5d3c3ca2" />

I tested the Swagger page and the test client. Everything should be more consistent now. Some different patterns were lightly explored and should be discussed:
- Class hierarchy, vs topological hierarchy (composes vs organizes)
- Differences between an implementations persistence of a graph vs the minimum required response from the RFC
- Value meta vs Object meta
- Ad hoc meta from data source payload

Not sure if I broke the MQTT data source, didn't have time to test. The most important changes were to the mock data, proposing what payloads look like.

**RFC Issues**

Sections 3.1.1 and 3.1.2 refer to Object metadata, but some of the fields are more appropriate for value metadata.

We do not specify common optional value metadata fields (VQTs), they have been proposed in the mock data.

 **Key Changes**

 1. Record Structure Standardization

  - Renamed values array to records throughout mock data and related code
  - Implemented standard record structure: Each record now has {value, quality, timestamp} format
  - Value field contains the actual data (primitive or complex object)
  - Quality and timestamp are record-level metadata
  - Supports additional custom metadata fields (e.g., localTimestamp)

 2. Object Type Schema Loading

  - Updated get_object_types() and get_object_type_by_id() to load schemas from Namespace-specific JSON files
  - Added _load_schema_definition() helper to resolve schema pointers like "Namespaces/abelara.json#types/state-type"
  - Implements caching for performance
  - Returns complete type definitions with actual schema instead of just string pointers

 3. Value Methods Enhancement

  - Added includeMetadata parameter: Controls whether to return just values or full records with metadata
  - Added returnHistory parameter: Distinguishes between single value (/value) vs all historical values (/history)
  - /value endpoint now returns only the most recent value
  - /history without time range returns all historical values
  - Both endpoints respect includeMetadata flag

 4. Update Method Improvements

  - Added intelligent type coercion for primitive types (string ↔ int ↔ float)
  - Properly updates the value field within record structure
  - Automatically updates timestamps at both record and value levels

 5. Subscription System Fixes

  - Fixed value updates for primitive values: Mock updater now properly randomizes numeric primitives like sensor
  readings
  - Standardized subscription responses:
    - includeMetadata=false: Returns only {elementId, value}
    - includeMetadata=true: Returns {elementId, value, quality, timestamp, ...} with all record metadata
  - Removed dataType field from responses
  - Added response_model_exclude_none=True to properly omit null fields
  - Subscription preferences stored per-subscription

 6. Related Instances Enhancement

  - Made relationship_type parameter optional in get_related_instances()
  - When omitted, returns all related instances regardless of relationship type
  - When specified, filters to specific relationship type