### PR TITLE
Fix SSE streaming to use proper EventSource format

### DIFF
--- a/demo/client/test_client.py
+++ b/demo/client/test_client.py
@@ -459,7 +459,9 @@ async def read_sse(url: str):
             async with client.stream("GET", url, headers={"Accept": "text/event-stream"}) as response:
                 response.raise_for_status()
                 async for line in response.aiter_lines():
-                    if line:
+                    if line.startswith("data: "):
+                        print(line[6:])  # Strip "data: " prefix for clean JSON output
+                    elif line:
                         print(line)
     except asyncio.CancelledError:
         pass

--- a/demo/server/routers/subscriptions.py
+++ b/demo/server/routers/subscriptions.py
@@ -211,7 +211,7 @@ async def stream_subscription(request: Request, subscriptionId: str):
         try:
             while True:
                 update = await queue.get()
-                yield json.dumps([update]) + "\n"
+                yield f"data: {json.dumps([update])}\n\n"
         except Exception as e:
             print(f"[SSE] Stream ended: {e}")
         finally:
@@ -230,7 +230,7 @@ async def stream_subscription(request: Request, subscriptionId: str):
     sub.handler = push_update_to_client
     sub.event_loop = loop
     sub.streaming_response = StreamingResponse(
-        event_stream(), media_type="application/json"
+        event_stream(), media_type="text/event-stream"
     )
 
     # Clear the queue when switching to streaming (per requirements)


### PR DESCRIPTION
This is a surgical change to fix an issue with our SSE stream format.

Server:
- Prefix messages with "data: " as required by SSE spec
- End messages with double newline (\n\n)
- Set Content-Type to text/event-stream

Client:
- Strip "data: " prefix from SSE messages for clean JSON output