### PR TITLE
Issue 204: Added TTL to subscriptions.

### DIFF
--- a/spec/IMPLEMENTATION_GUIDE.md
+++ b/spec/IMPLEMENTATION_GUIDE.md
@@ -942,7 +942,7 @@ This returns the basic configuration and state of all subscriptions, but exclude
 
 ```json
 {
-  "subscriptions": [
+  "subscriptionIds": [
     {
     "subscriptionId": 0,
     "created": "2026-01-29T19:56:06Z",


### PR DESCRIPTION
This change adds a TTL to subscriptions. The client can provide a value and the server responds with the value. After items are registered, if a subscription doesn't have an active SSE or a call to /sync doesn't occur in the TTL, the subscription is deleted by the server.