### PR TITLE
Issue 202:  Subscription Scope

### DIFF
--- a/demo/server/models.py
+++ b/demo/server/models.py
@@ -139,17 +139,41 @@ class HistoricalUpdateResult(BaseModel):
 
 
 class CreateSubscriptionRequest(BaseModel):
-    pass  # No fields needed - subscription starts monitoring on /register
+    displayName: Optional[str] = Field(None, description="Optional friendly name for the subscription")
 
 
 class CreateSubscriptionResponse(BaseModel):
     subscriptionId: str
-    message: str
+    displayName: Optional[str] = None
+
+
+class ListSubscriptionsRequest(BaseModel):
+    subscriptionIds: List[str] = Field(..., description="List of subscription IDs to retrieve")
+
+
+class SubscriptionDetail(BaseModel):
+    subscriptionId: str
+    displayName: Optional[str] = None
+    elementIds: List[str] = []
 
 
 class RegisterMonitoredItemsRequest(BaseModel):
+    subscriptionId: str = Field(..., description="The subscription to register items with")
     elementIds: List[str]
     maxDepth: Optional[int] = 1  # 0 means infinite recursion, 1 means no recursion, >1 recurses to that depth
+
+
+class StreamRequest(BaseModel):
+    subscriptionId: str = Field(..., description="The subscription to open a stream for")
+
+
+class SyncRequest(BaseModel):
+    subscriptionId: str = Field(..., description="The subscription to sync")
+    through: Optional[int] = Field(None, description="Acknowledge all updates through this sequence number before returning new ones")
+
+
+class DeleteSubscriptionsRequest(BaseModel):
+    subscriptionIds: List[str] = Field(..., description="List of subscription IDs to delete")
 
 
 class SyncResponseItem(BaseModel):
@@ -159,23 +183,6 @@ class SyncResponseItem(BaseModel):
     value: Any
     timestamp: Optional[str] = None
     quality: Optional[str] = None
-
-
-class SyncRequest(BaseModel):
-    through: Optional[int] = Field(None, description="Acknowledge all updates through this sequence number before returning new ones")
-
-
-class UnsubscribeRequest(BaseModel):
-    subscriptionIds: List[str]
-
-
-class SubscriptionSummary(BaseModel):
-    subscriptionId: int
-    created: str
-
-
-class GetSubscriptionsResponse(BaseModel):
-    subscriptionIds: List[SubscriptionSummary]
 
 
 # Request models for POST endpoints (GET to POST refactor)

--- a/demo/server/routers/subscriptions.py
+++ b/demo/server/routers/subscriptions.py
@@ -1,23 +1,27 @@
-from fastapi import APIRouter, HTTPException, Request, Path
+from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from typing import List, Optional, Any, Callable
 from datetime import datetime, timezone
 import asyncio
 import json
 import time
+import uuid
 from pydantic import BaseModel, Field, ConfigDict
-from models import CreateSubscriptionRequest, CreateSubscriptionResponse
-from models import RegisterMonitoredItemsRequest
-from models import GetSubscriptionsResponse, SubscriptionSummary
-from models import SyncRequest
-from fastapi import Body
+from models import (
+    CreateSubscriptionRequest, CreateSubscriptionResponse,
+    ListSubscriptionsRequest, SubscriptionDetail,
+    RegisterMonitoredItemsRequest,
+    StreamRequest, SyncRequest,
+    DeleteSubscriptionsRequest,
+)
 from data_sources.data_interface import I3XDataSource
 from .utils import getSubscriptionValue
 
 
 # Not required, but showing what information is stored for simulated subscriptions
 class Subscription(BaseModel):
-    subscriptionId: int
+    subscriptionId: str
+    displayName: Optional[str] = None
     created: str
     maxDepth: int = 1  # Depth to follow HasComponent relationships (0=infinite, 1=no recursion, N=recurse N levels)
     monitoredItems: List[str] = []
@@ -45,54 +49,12 @@ def get_data_source(request: Request) -> I3XDataSource:
     return request.app.state.data_source
 
 
-# GET /subscriptions - List all subscriptions
-@subs.get(
-    "/subscriptions",
-    summary="List Subscriptions",
-    response_model=GetSubscriptionsResponse,
-    operation_id="listSubscriptions",
-)
-def get_subscriptions(request: Request):
-    """List all subscriptions including their ID and settings (does not include registered objects)"""
-    subscriptions = []
-    for sub in request.app.state.I3X_DATA_SUBSCRIPTIONS:
-        subscriptions.append(
-            SubscriptionSummary(
-                subscriptionId=sub.subscriptionId,
-                created=sub.created
-            )
-        )
-    return GetSubscriptionsResponse(subscriptionIds=subscriptions)
-
-
-# GET /subscriptions/{id} - Get a single subscription with full details
-@subs.get(
-    "/subscriptions/{subscriptionId}",
-    summary="Get Subscription",
-    operation_id="getSubscription",
-)
-def get_subscription(request: Request, subscriptionId: str):
-    """Get a single subscription including settings and registered objects"""
-    sub = next(
-        (
-            s
-            for s in request.app.state.I3X_DATA_SUBSCRIPTIONS
-            if str(s.subscriptionId) == str(subscriptionId)
-        ),
+def _find_sub(request: Request, subscription_id: str) -> Optional[Subscription]:
+    """Locate a subscription by ID"""
+    return next(
+        (s for s in request.app.state.I3X_DATA_SUBSCRIPTIONS if s.subscriptionId == subscription_id),
         None,
     )
-    if not sub:
-        raise HTTPException(status_code=404, detail="Subscription not found")
-
-    return {
-        "subscriptionId": sub.subscriptionId,
-        "created": sub.created,
-        "isStreaming": sub.is_streaming,
-        "queuedUpdates": len(sub.pendingUpdates),
-        "nextSequence": sub.nextSequence,
-        "lastAckedSequence": sub.lastAckedSequence,
-        "objects": sub.monitoredItems
-    }
 
 
 # RFC 4.2.3.1 - Create Subscription
@@ -103,14 +65,15 @@ def get_subscription(request: Request, subscriptionId: str):
     operation_id="createSubscription",
 )
 def create_subscription(request: Request, subscription: CreateSubscriptionRequest):
-    """Create a new subscription. Monitoring starts when objects are registered via /register"""
+    """Create a new subscription. Returns a unique subscriptionId the client must cache.
+    There is no way to list all subscriptions; the client must track the returned ID."""
 
-    # For now make the subscription ID a simple index to make manual testing easy, but should be a UUID
-    subscriptionId = str(len(request.app.state.I3X_DATA_SUBSCRIPTIONS))
+    subscription_id = str(uuid.uuid4())
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     ttl = getattr(request.app.state, "subscription_ttl_seconds", 300)
     new_sub = Subscription(
-        subscriptionId=subscriptionId,
+        subscriptionId=subscription_id,
+        displayName=subscription.displayName,
         created=now,
         last_activity=now,
         ttl_seconds=ttl,
@@ -118,28 +81,40 @@ def create_subscription(request: Request, subscription: CreateSubscriptionReques
     request.app.state.I3X_DATA_SUBSCRIPTIONS.append(new_sub)
 
     return CreateSubscriptionResponse(
-        subscriptionId=subscriptionId, message="Subscription created successfully."
+        subscriptionId=subscription_id,
+        displayName=subscription.displayName,
     )
+
+
+# POST /subscriptions/list - Retrieve details for one or more subscriptions
+@subs.post(
+    "/subscriptions/list",
+    summary="List Subscriptions",
+    operation_id="listSubscriptions",
+)
+def list_subscriptions(request: Request, req: ListSubscriptionsRequest):
+    """Return details for the specified subscriptions, including registered elementIds."""
+    result = []
+    for sub_id in req.subscriptionIds:
+        sub = _find_sub(request, sub_id)
+        if sub:
+            result.append(SubscriptionDetail(
+                subscriptionId=sub.subscriptionId,
+                displayName=sub.displayName,
+                elementIds=sub.monitoredItems,
+            ))
+    return result
 
 
 # RFC 4.2.3.2 - Register Monitored Items
 @subs.post(
-    "/subscriptions/{subscriptionId}/register",
+    "/subscriptions/register",
     summary="Register Monitored Items",
     operation_id="registerMonitoredItems",
 )
-def register_objects(
-    request: Request, subscriptionId: str, req: RegisterMonitoredItemsRequest
-):
-    """Add a list of object to the subscription"""
-    sub = next(
-        (
-            s
-            for s in request.app.state.I3X_DATA_SUBSCRIPTIONS
-            if str(s.subscriptionId) == str(subscriptionId)
-        ),
-        None,
-    )
+def register_objects(request: Request, req: RegisterMonitoredItemsRequest):
+    """Add objects to the subscription. subscriptionId is passed in the request body."""
+    sub = _find_sub(request, req.subscriptionId)
     if not sub:
         raise HTTPException(status_code=404, detail="Subscription not found")
 
@@ -173,24 +148,16 @@ def register_objects(
         "totalObjects": len(sub.monitoredItems)
     }
 
+
 # RFC 4.2.3.2 - Unregister Monitored Items
 @subs.post(
-    "/subscriptions/{subscriptionId}/unregister",
+    "/subscriptions/unregister",
     summary="Remove Monitored Items",
     operation_id="removeMonitoredItems",
 )
-def unregister_objects(
-    request: Request, subscriptionId: str, req: RegisterMonitoredItemsRequest
-):
-    """Remove a list of objects from the subscription"""
-    sub = next(
-        (
-            s
-            for s in request.app.state.I3X_DATA_SUBSCRIPTIONS
-            if str(s.subscriptionId) == str(subscriptionId)
-        ),
-        None,
-    )
+def unregister_objects(request: Request, req: RegisterMonitoredItemsRequest):
+    """Remove objects from the subscription. subscriptionId is passed in the request body."""
+    sub = _find_sub(request, req.subscriptionId)
     if not sub:
         raise HTTPException(status_code=404, detail="Subscription not found")
 
@@ -218,22 +185,16 @@ def unregister_objects(
         "message": f"Unregistered {removed_count} objects from subscription."
     }
 
-# GET /subscriptions/{id}/stream - Open SSE stream
-@subs.get(
-    "/subscriptions/{subscriptionId}/stream",
+
+# POST /subscriptions/stream - Open SSE stream
+@subs.post(
+    "/subscriptions/stream",
     summary="Stream Values (SSE)",
     operation_id="streamSubscription",
 )
-async def stream_subscription(request: Request, subscriptionId: str):
-    """Open a Server-Sent Events (SSE) stream. Switches from queue mode to streaming mode."""
-    sub = next(
-        (
-            s
-            for s in request.app.state.I3X_DATA_SUBSCRIPTIONS
-            if str(s.subscriptionId) == str(subscriptionId)
-        ),
-        None,
-    )
+async def stream_subscription(request: Request, req: StreamRequest):
+    """Open a Server-Sent Events (SSE) stream. subscriptionId is passed in the request body."""
+    sub = _find_sub(request, req.subscriptionId)
     if not sub:
         raise HTTPException(status_code=404, detail="Subscription not found")
 
@@ -258,7 +219,7 @@ async def stream_subscription(request: Request, subscriptionId: str):
             sub.handler = None
             sub.event_loop = None
             sub.streaming_response = None
-            print(f"[SSE] Subscription {subscriptionId} switched back to queue mode")
+            print(f"[SSE] Subscription {req.subscriptionId} switched back to queue mode")
 
     def push_update_to_client(update):
         asyncio.run_coroutine_threadsafe(queue.put(update), loop)
@@ -277,27 +238,20 @@ async def stream_subscription(request: Request, subscriptionId: str):
 
     return sub.streaming_response
 
-# RFC 4.2.3.3 Sync
+
+# RFC 4.2.3.3 - Sync
 @subs.post(
-    "/subscriptions/{subscriptionId}/sync",
+    "/subscriptions/sync",
     summary="Sync Values",
     operation_id="syncSubscription",
 )
-def sync_subscription(request: Request, subscriptionId: str, req: SyncRequest = Body(default=SyncRequest())):
-    """Acknowledge previously received updates (optional) and return all pending updates in one call.
+def sync_subscription(request: Request, req: SyncRequest):
+    """Acknowledge previously received updates and return all pending updates in one call.
 
     If `through` is provided, all queued updates with sequenceNumber <= through are removed first,
-    then the remaining (newer) updates are returned.
+    then the remaining (newer) updates are returned. subscriptionId is passed in the request body.
     """
-
-    sub = next(
-        (
-            s
-            for s in request.app.state.I3X_DATA_SUBSCRIPTIONS
-            if str(s.subscriptionId) == str(subscriptionId)
-        ),
-        None,
-    )
+    sub = _find_sub(request, req.subscriptionId)
     if not sub:
         raise HTTPException(status_code=404, detail="Subscription not found")
 
@@ -309,33 +263,35 @@ def sync_subscription(request: Request, subscriptionId: str, req: SyncRequest = 
     return {"success": True, "result": list(sub.pendingUpdates)}
 
 
-# 4.2.3.4 Unsubscribe by SubscriptionId
-@subs.delete(
-    "/subscriptions/{subscriptionId}",
-    summary="Delete Subscription",
-    operation_id="deleteSubscription",
+# POST /subscriptions/delete - Delete one or more subscriptions
+@subs.post(
+    "/subscriptions/delete",
+    summary="Delete Subscriptions",
+    operation_id="deleteSubscriptions",
 )
-def delete_subscription(request: Request, subscriptionId: str):
+def delete_subscriptions(request: Request, req: DeleteSubscriptionsRequest):
+    """Delete one or more subscriptions by ID. subscriptionIds are passed in the request body."""
     removed = []
     not_found = []
 
-    index = next(
-        (
-            i
-            for i, s in enumerate(request.app.state.I3X_DATA_SUBSCRIPTIONS)
-            if str(s.subscriptionId) == str(subscriptionId)
-        ),
-        None,
-    )
-    if index is not None:
-        removed.append(request.app.state.I3X_DATA_SUBSCRIPTIONS[index].subscriptionId)
-        request.app.state.I3X_DATA_SUBSCRIPTIONS.pop(index)
-    else:
-        not_found.append(subscriptionId)
+    for sub_id in req.subscriptionIds:
+        index = next(
+            (
+                i
+                for i, s in enumerate(request.app.state.I3X_DATA_SUBSCRIPTIONS)
+                if s.subscriptionId == sub_id
+            ),
+            None,
+        )
+        if index is not None:
+            removed.append(request.app.state.I3X_DATA_SUBSCRIPTIONS[index].subscriptionId)
+            request.app.state.I3X_DATA_SUBSCRIPTIONS.pop(index)
+        else:
+            not_found.append(sub_id)
 
     return {
-        "message": "Unsubscribe processed.",
-        "unsubscribed": removed,
+        "message": "Delete processed.",
+        "deleted": removed,
         "not_found": not_found,
     }
 

--- a/demo/server/test_app.py
+++ b/demo/server/test_app.py
@@ -182,19 +182,16 @@ class TestI3XEndpoints(unittest.TestCase):
         self.assertIsNotNone(subscription_id)
 
         # Step 2: Register monitored items
-        register_url = f"/subscriptions/{subscription_id}/register"
-        payload = {"elementIds": ["sensor-001"]}
-        response = self.client.post(register_url, json=payload)
+        payload = {"subscriptionId": subscription_id, "elementIds": ["sensor-001"]}
+        response = self.client.post("/subscriptions/register", json=payload)
         self.assertEqual(response.status_code, 200)
 
         # Step 3: Start streaming
-        stream_url = f"/subscriptions/{subscription_id}/stream"
-
         # We will run the streaming request in a separate thread to allow timeout
         results = []
 
         def stream_reader():
-            with self.client.stream("GET", stream_url) as stream_resp:
+            with self.client.stream("POST", "/subscriptions/stream", json={"subscriptionId": subscription_id}) as stream_resp:
                 self.assertEqual(stream_resp.status_code, 200)
                 count = 0
                 for line in stream_resp.iter_lines():

--- a/spec/IMPLEMENTATION_GUIDE.md
+++ b/spec/IMPLEMENTATION_GUIDE.md
@@ -771,27 +771,29 @@ Returns the last known value for one or more Objects.
 
 Returns the historical values for one or more Objects between a start and end time.
 
-**Request Body:**
+[TODO] - Sync reponse with v0.1.2
 
-```json
-{
-  "elementIds": [
-    "object-elementid-1"
-  ],
-  "startTime": "2026-03-03T13:00:00Z",
-  "endTime": "2026-03-03T12:00:00Z",
-  "maxDepth": 1
-}
-```
+**Request Body:**
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
+| `elementId` | string | No | Single elementId to query |
 | `elementIds` | string[] | No | One or more elementIds to query |
 | `startTime` | string | Yes | RFC 3339 timestamp for range start |
 | `endTime` | string | Yes | RFC 3339 timestamp for range end |
 | `maxDepth` | integer | No | Controls recursion depth |
 
-- The startTime MUST be more recent than the endTime and the results MUST be returned in descending order (most recent value first).
+```json
+{
+  "elementId": "string",
+  "elementIds": [
+    "string"
+  ],
+  "startTime": "string",
+  "endTime": "string",
+  "maxDepth": 1
+}
+```
 
 **Response:**
 
@@ -799,35 +801,26 @@ Returns the historical values for one or more Objects between a start and end ti
 {
     "results": [
         {
-            "elementId": "object-elementid-1",
+            "elementId": "string",
             "success": true,
             "data": [
                 {
+                "elementId": "string",
                 "isComposition": false,
                 "value": {
                     "temperature": 1,
                     "inletPressure": "2",
-                    "outletPressure": 0.11
+                    "outletPressure": 0.11139064
                 },
                 "quality": "GOOD",
-                "timestamp": "2026-01-29T16:00:00Z"
-              },
-              {
-                "isComposition": false,
-                "value": {
-                  "temperature": 3,
-                  "inletPressure": "4",
-                  "outletPressure": 0.22
-                },
-                "quality": "GOOD",
-                "timestamp": "2026-01-29T15:00:00Z"
+                "timestamp": "2026-01-29T16:37:41Z"
               }
             ]
         }
     ],
     "totalRequested": 1,
     "totalSuccess": 1,
-    "totalFailed": 0
+    "totalFailed": 0,
 }
 ```
 
@@ -897,8 +890,8 @@ Subscriptions allow clients to receive value changes in real-time for objects th
 
 | Mode | Description |
 |------|-------------|
-| **streaming** | A low QoS approach where value changes are sent as fast as possible using SSE (Server Sent Events). |
-| **sync** | A high QoS approach where value changes are queued and delivered when the client calls the sync API. |
+| **streaming** | Value changes are sent as fast as possible using SSE (Server Sent Events). |
+| **sync** | Value changes are queued and delivered when the client calls the sync API. |
 
 Streaming provides data as fast as possible, where Sync allows the client to control when data is delivered. The following sections describe common methods to setup and configure a subscription, followed by more details on the stream and sync modes.
 
@@ -907,90 +900,99 @@ Streaming provides data as fast as possible, where Sync allows the client to con
 Clients must first create a subscription in the server. Subscriptions have the following requirements:
 
 - The server MUST provide a unique subscriptionId to the client
-- [TODO] it would probably be useful for the client to be able to provide a name or some client id for the subscription to be returned in GET?
-- Servers SHOULD NOT share subscriptions across clients  [TODO] MGP - how will an i3X server know this?  Plus, I propose the technology/API should allow sharing subscriptions between clients, if the desire is to have a setup similar to multicast (any client can subscribe to this ID for all the data it needs to know)
+- Servers SHOULD NOT make subscriptions shareable across clients, but the standard doesn't enforce that
+- Servers SHOULD make the subscriptionId unique enough that the server can reasonably assume other clients cannot guess the subscriptionId
 
 ---
 
 #### `POST` /subscriptions
 
-Create a subscription.
+Creates a subscription and returns a unique subscription ID. The client is responsible for caching the subscriptionId to make future
+calls on the subscription. There is no way to list all subscriptions the client has created.
 
-**Parameters:** None
+The client can optionally pass in a friendly name for the subscription. This is intended to assist clients and servers and logging and tracking
+subscriptions.
 
-**Response:**
-
+**Parameters:**
 ```json
 {
-  "subscriptionId": "0",
-  "message": "Subscription created successfully."
+"displayName": "mySubscription"
 }
 ```
 
----
-
-#### `GET` /subscriptions
-
-List all subscriptions that the client has created.
-[TODO] - how does a server know which subscriptions a client created, especially after a disconnect/connect event? Should we specify clientID as a parameter for `POST` /subscriptions and `GET` /subscriptions?
-
-**Parameters:** None
+| Name | Type | Required | Description                                                 |
+|------|------|----------|-------------------------------------------------------------|
+| `displayName` | string | No       | Optional name to associate with the subscription.|
 
 **Response:**
 
 ```json
 {
-  "subscriptionIds": [
-    {
-      "subscriptionId": "0",
-      "created": "2026-01-29T19:56:06Z"
-    }
-  ]
+  "subscriptionId": "Xf9q8wL1b3YpQjV2Z7nRmK6sH4v0TgNd5eP2jF8hB1cQvLkS0UoMxZwA3yE6RrJt",
+  "displayName": "mySubscription"
+}
+```
+| Name | Type | Required | Description                                       |
+|------|------|----------|---------------------------------------------------|
+| `subscriptionId` | string | Yes      | Unique ID for the subscription                    |
+| `displayName` | string | Yes      | Friendly name for the subscription                |
+
+---
+
+#### `POST` /subscriptions/list
+
+Return the details of one or more subscriptions, including the registered objects.
+
+**Body Parameters:**
+```json
+{
+  "subscriptionIds": ["Xf9q8wL1b3YpQjV2Z7nRmK6sH4v0TgNd5eP2jF8hB1cQvLkS0UoMxZwA3yE6RrJt"]
 }
 ```
 
----
-
-#### `GET` /subscriptions/{subscriptionId}
-
-Return the details of a subscription, including the registered objects.
-
-**Path Parameters:**
-
-| Name | Type | Required | Description |
-|------|------|----------|-------------|
-| `subscriptionId` | string | Yes | The subscriptionId for the Subscription to get |
+| Name | Type         | Required | Description                                  |
+|------|--------------|----------|----------------------------------------------|
+| `subscriptionIds` | string array | Yes | List of subscription IDs |
 
 **Response:**
 
-[TODO] - created, isStreaming, queuedUpdates were added but never discussed. Do we need these?
-
 ```json
-{
-  "subscriptionId": 0,
-  "created": "2026-01-29T19:56:06Z",
-  "isStreaming": false,
-  "queuedUpdates": 20,
-  "objects": [
+[{
+  "subscriptionId": "Xf9q8wL1b3YpQjV2Z7nRmK6sH4v0TgNd5eP2jF8hB1cQvLkS0UoMxZwA3yE6RrJt",
+  "displayName": "mySubscription",
+  "elementIds": [
     "object-elementid-1",
     "object-elementid-2"
   ]
-}
+}]
 ```
+[TODO] - Removed created, isStreaming, queuedUpdates which is more status of the subscription. If we want this we should probably put it under a "status" attribute and maybe even add a switch like includeMetadata to return it, but leaving it out for now
 
+| Name | Type         | Required | Description                                                           |
+|------|--------------|----------|-----------------------------------------------------------------------|
+| `subscriptionId` | string array | Yes | Unique ID of the subscription                                         |
+| `displayName` | string array | Yes | Friendly name of thr subscription                                     |
+| `elementIds` | string array | Yes | Array of elementIds for all objects registered to the subscription |
+
+[TODO] - objects probably needs to be an [{}] because right now a subscription can have an elementid + maxdepth
 ---
 
-#### `DELETE` /subscriptions/{subscriptionId}
+#### `POST` /subscriptions/delete
 
-Delete a Subscription.
+Delete one or more subscriptions.
 
 - Servers SHOULD stop collecting data for Objects being monitored by the Subscription when it's deleted.
 
-**Path Parameters:**
+**Body Parameters:**
+```json
+{
+  "subscriptionIds": ["Xf9q8wL1b3YpQjV2Z7nRmK6sH4v0TgNd5eP2jF8hB1cQvLkS0UoMxZwA3yE6RrJt"]
+}
+```
 
-| Name | Type | Required | Description |
-|------|------|----------|-------------|
-| `subscriptionId` | string | Yes | The subscriptionId for the Subscription to delete |
+| Name | Type         | Required | Description                                  |
+|------|--------------|----------|----------------------------------------------|
+| `subscriptionIds` | string array | Yes | List of subscription IDs |
 
 **Response:**
 
@@ -1020,33 +1022,30 @@ Once a Subscription is created, a client can add and remove Objects to the Subsc
 
 ---
 
-#### `POST` /subscriptions/{subscriptionId}/register
+#### `POST` /subscriptions/register
 
 Register one or more Objects with a Subscription.
 
 - If an Object is registered more than once this MUST be ignored by the Server
 
-**Path Parameters:**
-
-| Name | Type | Required | Description |
-|------|------|----------|-------------|
-| `subscriptionId` | string | Yes | The subscriptionId for the Subscription to register items with |
-
 **Request Body:**
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `elementIds` | string[] | Yes | One or more elementIds to register |
-| `maxDepth` | integer | No | Controls recursion depth | [TODO] - MGP explain how maxDepth works.  Similar to values, where it only follows hasComponent relationships?
 
 ```json
 {
+  "subscriptionId": "Xf9q8wL1b3YpQjV2Z7nRmK6sH4v0TgNd5eP2jF8hB1cQvLkS0UoMxZwA3yE6RrJt",
   "elementIds": [
-    "elementId1"
+    "object-elementid-1",
+    "object-elementid-2"
   ],
   "maxDepth": 1
 }
 ```
+
+| Field            | Type | Required | Description |
+|------------------|------|----------|-------------|
+| `subscriptionId` | string | Yes | The subscriptionId for the Subscription to register items with |
+| `elementIds`        | string[] | Yes | One or more elementIds to register |
+| `maxDepth`       | integer | No | Controls recursion depth | [TODO] - MGP explain how maxDepth works.  Similar to values, where it only follows hasComponent relationships?
 
 **Response:**
 
@@ -1061,7 +1060,7 @@ Register one or more Objects with a Subscription.
 
 ---
 
-#### `POST` /subscriptions/{subscriptionId}/unregister
+#### `POST` /subscriptions/unregister
 
 Unregister one or more Objects from a Subscription.
 
@@ -1069,27 +1068,25 @@ Unregister one or more Objects from a Subscription.
 - Once an Object is unregistered the server SHOULD stop queuing new values for the Object on the Subscription
 - The server SHOULD NOT delete any prior queued values for the Object
 
-**Path Parameters:**
-
-| Name | Type | Required | Description |
-|------|------|----------|-------------|
-| `subscriptionId` | string | Yes | The subscriptionId for the Subscription to unregister items from |
-
 **Request Body:**
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `elementIds` | string[] | Yes | One or more elementIds to unregister |
-| `maxDepth` | integer | No | Controls recursion depth |
 
 ```json
 {
+  "subscriptionId": "Xf9q8wL1b3YpQjV2Z7nRmK6sH4v0TgNd5eP2jF8hB1cQvLkS0UoMxZwA3yE6RrJt",
   "elementIds": [
-    "elementId1"
+    "object-elementid-1",
+    "object-elementid-2"
   ],
   "maxDepth": 1
 }
 ```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `subscriptionId` | string | Yes | The subscriptionId for the Subscription to unregister items from |
+| `elementIds` | string[] | Yes | One or more elementIds to unregister |
+| `maxDepth` | integer | No | Controls recursion depth |
+
 
 **Response:**
 
@@ -1110,28 +1107,33 @@ Streaming sends values on the subscription to the client as they occur using SSE
 **How it works:**
 
 1. Client creates subscription via `POST /subscriptions`
-2. Client registers items via `POST /subscriptions/{id}/register`
+2. Client registers items via `POST /subscriptions/register`
    - The server starts queuing value changes for Objects
-3. Client opens SSE stream via `GET /subscriptions/{id}/stream`
+3. Client opens SSE stream via `POST /subscriptions/stream`
    - The server sends any values queued while the stream was closed
-4. Server sends values as they occur, with "at most once" delivery. If a client misses a message, it cannot be retreived.
+4. Server sends values as they occur, with "at most once" delivery. If a client misses a message, it cannot be retrieved.
 
 If the SSE connection is lost, the client can call the /stream endpoint again to re-open it.
 
 ---
 
-#### `GET` /subscriptions/{subscriptionId}/stream
+#### `POST` /subscriptions/stream
 
 Opens an SSE stream on the subscription to stream value changes from the server.
 
 - Server MUST only allow a single SSE stream per subscription
   - [TODO] is this enough or should we spec what happens if you spam the /stream endpoint? Ignore? Close the old and open new?
-  - MGP - should multiple clients be allowed to connect in a multcast-type pattern?
+  - MGP - should multiple clients be allowed to connect in a multicast-type pattern?
 - The Server MUST send queued updates when the stream is open
 - Clients MAY not receive updates if there are no value changes
   - [TODO] should register require queuing the current value of the Object?
 
-**Path Parameters:**
+**Body Parameters:**
+```json
+{
+  "subscriptionId": "Xf9q8wL1b3YpQjV2Z7nRmK6sH4v0TgNd5eP2jF8hB1cQvLkS0UoMxZwA3yE6RrJt"
+}
+```
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
@@ -1154,12 +1156,12 @@ Sync allows the client to control when value changes are received, and to explic
 **How it works:**
 
 1. Client creates subscription via `POST /subscriptions`
-2. Client registers items via `POST /subscriptions/{id}/register`
+2. Client registers items via `POST /subscriptions/register`
 3. Server queues updates as they occur, each assigned a monotonically increasing sequence number
-4. Client polls via `POST /subscriptions/{id}/sync` (no body on first call)
+4. Client polls via `POST /subscriptions/sync` (no `through` on first call)
 5. Server returns all pending updates
 6. Client processes the updates
-7. Client calls `POST /subscriptions/{id}/sync` again with `{"through": <lastSequenceNumber>}` to acknowledge the previous batch and receive any new updates in a single round trip
+7. Client calls `POST /subscriptions/sync` again with `{"subscriptionId": "...", "through": <lastSequenceNumber>}` to acknowledge the previous batch and receive any new updates in a single round trip
 8. Server removes acknowledged updates (sequenceNumber ≤ `through`) then returns the remaining queue
 9. Continue this process
 
@@ -1167,7 +1169,7 @@ This approach ensures updates are not lost if the client crashes between receivi
 
 ---
 
-#### `POST` /subscriptions/{subscriptionId}/sync
+#### `POST` /subscriptions/sync
 
 Returns all pending updates, acknowledging a previously received batch in the same call.
 
@@ -1177,26 +1179,26 @@ Returns all pending updates, acknowledging a previously received batch in the sa
 - Clients SHOULD omit `through` only on the first call, when there is nothing yet to acknowledge
 - Clients SHOULD provide `through` on every subsequent call, set to the highest `sequenceNumber` received in the previous response
 
-**Path Parameters:**
-
-| Name | Type | Required | Description |
-|------|------|----------|-------------|
-| `subscriptionId` | string | Yes | The subscriptionId for the Subscription to sync |
-
-**Request Body:**
+**Body Parameters:**
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
+| `subscriptionId` | string | Yes | The subscriptionId for the Subscription to sync |
 | `through` | integer | No — omit only on first call | Acknowledge all updates with sequenceNumber ≤ this value before returning new ones |
 
 First call (nothing to acknowledge yet):
 ```json
-{}
+{
+  "subscriptionId": "Xf9q8wL1b3YpQjV2Z7nRmK6sH4v0TgNd5eP2jF8hB1cQvLkS0UoMxZwA3yE6RrJt"
+}
 ```
 
 All subsequent calls (ack previous batch, fetch new):
 ```json
-{"through": 2}
+{
+  "subscriptionId": "Xf9q8wL1b3YpQjV2Z7nRmK6sH4v0TgNd5eP2jF8hB1cQvLkS0UoMxZwA3yE6RrJt",
+  "through": 2
+}
 ```
 
 **Response:**


### PR DESCRIPTION
Changes the subscription API to limit scope of subscriptions to the client that creates them. It does not force this, but servers are encouraged to create a unique & hard to guess subscription ID on create, and clients use the ID to perform operations on the subscription.

The PR removes the GET /subscriptions endpoint and replaces is with a POST subscriptions/list, where the client must pass in the unique IDs of one or more of the subscriptions.

Lastly this PR introduces a subscription "displayName" optionally provided by the client to make it easier to log/track subscriptions.