### PR TITLE
Add GET /info endpoint for server health and capability discovery

### DIFF
--- a/demo/server/app.py
+++ b/demo/server/app.py
@@ -9,6 +9,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.openapi.docs import get_redoc_html
+from routers.info import info
 from routers.namespaces import ns
 from routers.typeDefinitions import typeDefinitions
 from routers.objects import explore, query, update
@@ -170,8 +171,11 @@ async def http_exception_handler(request: Request, exc: HTTPException):
 # Setup app state (data source will be set after config is loaded)
 app.state.I3X_DATA_SUBSCRIPTIONS = []  # List[Subscription]
 app.state.subscription_ttl_seconds = config.get("subscriptions", {}).get("ttl_seconds", 300)
+app.state.app_config = app_config
+app.state.capabilities_config = config.get("capabilities", {})
 
-# Include namespaces
+# Include routers
+app.include_router(info)
 app.include_router(ns)
 app.include_router(typeDefinitions)
 app.include_router(explore)

--- a/demo/server/config-example.json
+++ b/demo/server/config-example.json
@@ -36,6 +36,16 @@
     "subscriptions": {
         "ttl_seconds": 300
     },
+    "capabilities": {
+        "query": {
+            "history": true
+        },
+        "update": {
+            "current": true,
+            "history": false
+        },
+        "subscribe": true
+    },
     "data_source_routing": {
         "primary": "exploratory",
         "get_namespaces": "exploratory",

--- a/demo/server/routers/info.py
+++ b/demo/server/routers/info.py
@@ -1,0 +1,31 @@
+from fastapi import APIRouter, Request
+from .utils import success_response
+
+info = APIRouter(prefix="", tags=["Info"])
+
+I3X_SPEC_VERSION = "1.0"
+
+
+# RFC - Server Capabilities
+@info.get("/info", summary="Server Info", operation_id="getInfo")
+def get_info(request: Request):
+    """Returns the server version and capabilities. May be used as a health check.
+    This endpoint does not require authentication."""
+    app_config = getattr(request.app.state, "app_config", {})
+    capabilities_config = getattr(request.app.state, "capabilities_config", {})
+
+    return success_response({
+        "specVersion": I3X_SPEC_VERSION,
+        "serverVersion": app_config.get("version"),
+        "serverName": app_config.get("title"),
+        "capabilities": {
+            "query": {
+                "history": capabilities_config.get("query", {}).get("history", True),
+            },
+            "update": {
+                "current": capabilities_config.get("update", {}).get("current", True),
+                "history": capabilities_config.get("update", {}).get("history", False),
+            },
+            "subscribe": capabilities_config.get("subscribe", True),
+        },
+    })


### PR DESCRIPTION
Implements the /info endpoint from the RFC spec, returning specVersion, serverVersion, serverName, and a capabilities object. The endpoint does not require authentication and may be used as a health check.