### PR TITLE
Arrays of Types or Tags

### DIFF
--- a/RFC for Contextualized Manufacturing Information API.md
+++ b/RFC for Contextualized Manufacturing Information API.md
@@ -71,6 +71,9 @@ The reader will observe that the API requires the underlying platform to support
 
 ### 3.1.2 Optional Object Metadata
 
+- TypeElementIds: a string or an array of strings containing the elementIds of any ObjectTypes associated with this object
+- Relationships: a list of related objects
+- sourceRelationship: the name of the relationship that caused this object to be included in query results, if any
 - Interpolation: if the element value is interpolated, rather than stored, indicate the interpolation method
 - EngUnit: a string indicating the engineering unit for measuring the element value. Where present, the definitions found in [UNECE Recommendation Number 20](https://unece.org/trade/documents/2021/06/uncefact-rec20-0) MUST be used.
 - Quality: a data quality indicator following the standard established by the [OPC UA standard status codes](https://reference.opcfoundation.org/Core/Part8/v104/docs/A.3.2.3#_Ref377938607). If data quality is not available, a CMIP may omit this metadata field.


### PR DESCRIPTION
Updating the RFC to include existing JSON fields, and suggesting a change to allow an **array** of typeIds attached to a single Object.

This is because users will frequently want to be able to search for objects in their hierarchy based on more than one criteria, and having only one type per object makes that difficult. In your own example, Pump 101 is marked as a 'work-unit'. What if the user wanted to search for _pumps_? What about _pumps with variable speed drives_? A site might have many different forms of work-unit, and i3X doesn't allow the user to differentiate them.

Assets with multiple, additive types helps address this issue. 

The concept was brought up in issue #273 and dismissed, but the reasons for the rejection were based on why multiple-inheritance is a poor choice for **code**. This isn't about code - it's simply about inheriting properties. For a visual about how this works in our platform, see https://optrix-my.sharepoint.com/:p:/g/personal/sharding_optrix_com_au/EWa_C1S_pDNFhAfVmzuwcewB_wi1sUSBIQr2Ll2bGCLbCw?e=NtcdoT&action=embedview&wdAr=1.7777777777777777 (note, this presentation also covers how our version ot types are also hierarchial - we are not requesting that this be supported in i3x). 

**An Alternative Option**

I know that making types additive is limited mainly to our product, so might not be worth the time and complexity. In which case, I'd like to suggest **tags**. Tags would have _no_ effect on data and simply be used to group and describe objects. An object might have a type of 'work-unit' but then be **tagged** as 'pump', 'vsd' and 'critical'. These tags could then be used just like typeElementIds to filter objects.