### PR TITLE
Support for Alternate Object Names

### DIFF
--- a/RFC for Contextualized Manufacturing Information API.md
+++ b/RFC for Contextualized Manufacturing Information API.md
@@ -71,6 +71,7 @@ The reader will observe that the API requires the underlying platform to support
 
 ### 3.1.2 Optional Object Metadata
 
+- AlternateNames: a list of strings containing alternative names/ID numbers for this asset
 - Interpolation: if the element value is interpolated, rather than stored, indicate the interpolation method
 - EngUnit: a string indicating the engineering unit for measuring the element value. Where present, the definitions found in [UNECE Recommendation Number 20](https://unece.org/trade/documents/2021/06/uncefact-rec20-0) MUST be used.
 - Quality: a data quality indicator following the standard established by the [OPC UA standard status codes](https://reference.opcfoundation.org/Core/Part8/v104/docs/A.3.2.3#_Ref377938607). If data quality is not available, a CMIP may omit this metadata field.


### PR DESCRIPTION
The various people at a site often disagree about the name of the particular piece of equipment or sensor.

While having a plain-language name is an excellent idea, most engineers and operators may refer to sensors by their tag names/equipment reference numbers instead. And in many cases, these can be distorted - we often find maintenance staff using slightly different identifiers to engineers, because someone typed the wrong information several years before.

As such, it would be useful to be able to both assign and search for objects via _alternative names_. This way, an object named "Main Pump" can also be accessed by it's reference number, 'PU-101', or by it's electrical motor number 'VSD9923'.

This would likely require the addition of a **/objects/search** endpoint, or a new parameter for **/objects/list** that returns a list of all objects that match the alternate name.