### PR TITLE
Issue 181: Refined restrictions on elementids

### DIFF
--- a/spec/IMPLEMENTATION_GUIDE.md
+++ b/spec/IMPLEMENTATION_GUIDE.md
@@ -187,12 +187,10 @@ An ElementId is a platform-specific unique string identifier. Each element in th
 
 **Requirements:**
 - ElementIds MUST be strings with the following constraints
-  - [TODO] - put some limits around ElementIds?
-  - MUST be case insensitive
+  - MUST be case-insensitive
   - MUST not contain leading or trailing white spaces
 - ElementIds MUST be unique within the scope of the platform
 - ElementIds SHOULD be persistent (the same element always has the same ID)
-  - [TODO] SHOULD or MUST be persistent?
 - ElementIds SHOULD be human-readable when practical
 
 Below are examples of ElementIds.

--- a/spec/IMPLEMENTATION_GUIDE.md
+++ b/spec/IMPLEMENTATION_GUIDE.md
@@ -189,6 +189,7 @@ An ElementId is a platform-specific unique string identifier. Each element in th
 - ElementIds MUST be strings with the following constraints
   - MUST be case-insensitive
   - MUST not contain leading or trailing white spaces
+  - MUST not contain non-printable characters
 - ElementIds MUST be unique within the scope of the platform
 - ElementIds SHOULD be persistent (the same element always has the same ID)
 - ElementIds SHOULD be human-readable when practical


### PR DESCRIPTION
Removed TODOs. Don't allow leading/trailing spaces in ElementIds.