### PR TITLE
Update demo data sources: null parentId for root objects

### DIFF
--- a/demo/server/data_sources/cnc_mock/cnc_data.py
+++ b/demo/server/data_sources/cnc_mock/cnc_data.py
@@ -162,10 +162,9 @@ CNC_DATA = {
             "displayName": "CNC Work Center",
             "namespaceUri": ISA95_NAMESPACE,
             "typeElementId": "work-center-type",
-            "parentId": "/",
+            "parentId": None,
             "isComposition": False,
             "relationships": {
-                "HasParent": "/",
                 "HasChildren": ["cnc-001", "cnc-002"]
             },
             "location": "Building A, Floor 2",

--- a/demo/server/data_sources/cnc_mock/cnc_data_source.py
+++ b/demo/server/data_sources/cnc_mock/cnc_data_source.py
@@ -79,7 +79,7 @@ class CNCDataSource(I3XDataSource):
             results = instances
 
         if root:
-            results = [i for i in results if i.get("parentId") == "/"]
+            results = [i for i in results if i.get("parentId") is None]
 
         # Filter out records member from each instance before returning
         filtered_results = []

--- a/demo/server/data_sources/ignition_cnc/ignition_cnc_data.py
+++ b/demo/server/data_sources/ignition_cnc/ignition_cnc_data.py
@@ -246,11 +246,10 @@ IGNITION_CNC_DATA = {
             "displayName": "CNC Shop Floor",
             "namespaceUri": "http://opcfoundation.org/UA/",
             "typeElementId": TYPE_IDS["folder-type"],
-            "parentId": "/",
+            "parentId": None,
             "isComposition": False,
             "static": True,
             "relationships": {
-                "HasParent": "/",
                 "HasChildren": ["cnc-machine-001"]
             }
         },

--- a/demo/server/data_sources/ignition_cnc/ignition_cnc_data_source.py
+++ b/demo/server/data_sources/ignition_cnc/ignition_cnc_data_source.py
@@ -143,7 +143,7 @@ class IgnitionCNCDataSource(I3XDataSource):
             results = instances
 
         if root:
-            results = [i for i in results if i.get("parentId") == "/"]
+            results = [i for i in results if i.get("parentId") is None]
 
         # Filter out records member from each instance before returning
         filtered_results = []

--- a/demo/server/data_sources/mock/mock_data.py
+++ b/demo/server/data_sources/mock/mock_data.py
@@ -106,8 +106,7 @@ I3X_DATA = {
             "displayName": "pump-station",
             "description": "West facility pump station supplying coolant to the primary production area",
             "typeElementId": "work-center-type",
-            # A "/" is used to indicate this object is attached to the root
-            "parentId": "/",
+            "parentId": None,
             # A platform implementation would read its graph in order to populate these required response fields.
             #   This element has child objects, but they do not make up the data of this element, so this element is NOT complex
             #   We would expect a client would not want to recurse through these relationships by default
@@ -118,7 +117,6 @@ I3X_DATA = {
             "lastMaintainedDate": "August 1, 2001",
             # This is where we maintain the graph relationships used above and in the /related endpoints for the mock data
             "relationships": {
-                "HasParent": "/",
                 "HasChildren": [
                     "pump-101",
                     "tank-201",

--- a/demo/server/data_sources/mock/mock_data_source.py
+++ b/demo/server/data_sources/mock/mock_data_source.py
@@ -180,7 +180,7 @@ class MockDataSource(I3XDataSource):
             results = instances
 
         if root:
-            results = [i for i in results if i.get("parentId") == "/"]
+            results = [i for i in results if i.get("parentId") is None]
 
         # Filter out records member from each instance before returning (unique to mock data)
         filtered_results = []


### PR DESCRIPTION
## Clean-up demo data

Root objects in the mock, cnc-mock, and ignition-cnc data sources now use parentId: null instead of the v0 sentinel value "/". The root=true filter in each data source checks parentId is None accordingly. The MQTT data source is unchanged as it uses "/" as a real addressable node.