### PR TITLE
Issue 296

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ ehthumbs.db
 *.sqlite3
 prototypes/python3/server/.claude/settings.local.json
 /.vs
+.claude/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+Changes accepted between Beta and the 1.0 release.
+
+All notable changes to the i3X RFC, Implementation Guide, and demo are documented here so that implementers can identify the exact deltas they need to adopt.
+
+## Summary
+
+- 2026-04-23 — `/sync` returns HTTP 206 when subscription queue overflow causes updates to be dropped | #258 #288
+- 2026-04-23 — Error responses now use a `problemDetail` object (`title`, `status`, `detail`) in place of the previous `error` object (`code`, `message`). Applied to all endpoints and the demo server | #294 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-Changes accepted between Beta and the 1.0 release.
+Changes accepted between 1.0 Beta and the 1.0 Release.
 
 All notable changes to the i3X RFC, Implementation Guide, and demo are documented here so that implementers can identify the exact deltas they need to adopt.
 
 ## Summary
 
-- 2026-04-23 — `/sync` returns HTTP 206 when subscription queue overflow causes updates to be dropped | #258 #288
-- 2026-04-23 — Error responses now use a `problemDetail` object (`title`, `status`, `detail`) in place of the previous `error` object (`code`, `message`). Applied to all endpoints and the demo server | #294 
+- 2026-04-23 — `/sync` returns HTTP 206 when subscription queue overflow causes updates to be dropped | [#258](https://github.com/cesmii/i3X/issues/258) [#288](https://github.com/cesmii/i3X/issues/288) 
+- 2026-04-23 — Error responses now use a `problemDetail` object (`title`, `status`, `detail`) in place of the previous `error` object (`code`, `message`). Applied to all endpoints and the demo server | [#294](https://github.com/cesmii/i3X/issues/294) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,5 +6,6 @@ All notable changes to the i3X RFC, Implementation Guide, and demo are documente
 
 ## Summary
 
+- 2026-04-28 — `extendedAttributes` renamed to `schemaExtensions` in the object metadata response (RFC §3.1.1, Implementation Guide, and demo server)
 - 2026-04-23 — `/sync` returns HTTP 206 when subscription queue overflow causes updates to be dropped | [#258](https://github.com/cesmii/i3X/issues/258) [#288](https://github.com/cesmii/i3X/issues/288) 
 - 2026-04-23 — Error responses now use a `problemDetail` object (`title`, `status`, `detail`) in place of the previous `error` object (`code`, `message`). Applied to all endpoints and the demo server | [#294](https://github.com/cesmii/i3X/issues/294) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the i3X RFC, Implementation Guide, and demo are documente
 
 ## Summary
 
+- 2026-04-28 — `PUT /objects/{elementId}/value` and `PUT /objects/{elementId}/history` replaced by `POST /objects/value/update` and `POST /objects/history/update`, accepting elementIds in the request body as `{"updates": [{"elementId": "...", "value": {...}}, ...]}` and returning bulk responses. `GET /objects/{elementId}/history` removed — use `POST /objects/history` instead. (RFC §4.2.2, Implementation Guide, demo server)
 - 2026-04-28 — `extendedAttributes` renamed to `schemaExtensions` in the object metadata response (RFC §3.1.1, Implementation Guide, and demo server)
 - 2026-04-23 — `/sync` returns HTTP 206 when subscription queue overflow causes updates to be dropped | [#258](https://github.com/cesmii/i3X/issues/258) [#288](https://github.com/cesmii/i3X/issues/288) 
 - 2026-04-23 — Error responses now use a `problemDetail` object (`title`, `status`, `detail`) in place of the previous `error` object (`code`, `message`). Applied to all endpoints and the demo server | [#294](https://github.com/cesmii/i3X/issues/294) 

--- a/RFC for Contextualized Manufacturing Information API.md
+++ b/RFC for Contextualized Manufacturing Information API.md
@@ -302,6 +302,7 @@ This method is used only for sync subscriptions, and is called with a specific S
 
 When servicing the Sync call, the implementation MUST respond with an array of updates for elements that have changed since the last Sync call. Each update in the response array MUST include:
 - elementId: the ElementId of the changed element
+- sequenceNumber: the monotonically increasing sequence number assigned to this update
 - value: the new value (with recursive structure if maxDepth was specified during registration)
 - quality: the quality indicator
 - timestamp: the timestamp of the change
@@ -309,6 +310,15 @@ When servicing the Sync call, the implementation MUST respond with an array of u
 If no elements have changed since the last Sync call, the response MUST be an empty array.
 
 Each update in the queue carries a monotonically increasing `sequenceNumber`. The client MAY include a `lastSequenceNumber` in the Sync call to acknowledge all updates with a sequence number at or below that value; the implementation MUST remove those acknowledged updates before returning the remaining queue. If `lastSequenceNumber` is omitted the implementation MUST NOT clear the queue. The implementation must maintain state for all pending (un-acknowledged) updates, subject to server-imposed queue limits.
+
+When the server drops updates due to queue limits, it MUST signal data loss to the client by returning HTTP 206 (Partial Content) instead of HTTP 200. The response body MUST use `"success": true` with the standard `result` payload and an additional top-level `problemDetail` object. The `problemDetail` object MUST include the following fields:
+- `title`: a short human-readable summary of the problem
+- `status`: the HTTP status code (206)
+- `detail`: a human-readable explanation of what was lost and why
+
+The `result` array in a 206 response MUST contain all currently available pending updates.
+
+Clients can detect the extent of data loss from the sequence gap: all sequence numbers between `lastSequenceNumber + 1` and the lowest `sequenceNumber` in the returned `result` array were dropped by the server and cannot be retrieved. Clients MUST NOT attempt to retrieve dropped updates. Clients SHOULD log or alert on receipt of a 206 response and MUST continue polling using the highest `sequenceNumber` from the response as the next `lastSequenceNumber`.
 
 ##### 4.2.3.5 Delete Subscription
 
@@ -334,12 +344,20 @@ All responses MUST be wrapped in a standard envelope. Successful single-item res
 ```
 Successful bulk responses (accepting an array of ElementIds) MUST use a `results` array with per-item success or failure indicated inline:
 ```json
-{ "success": false, "results": [ { "success": true, "elementId": "...", "result": <data> }, { "success": false, "elementId": "...", "error": { "code": 404, "message": "..." } } ] }
+{ "success": false, "results": [ { "success": true, "elementId": "...", "result": <data> }, { "success": false, "elementId": "...", "problemDetail": { "title": "Not Found", "status": 404, "detail": "..." } } ] }
 ```
 The top-level `success` is `false` if any item in a bulk response failed. Failure responses MUST use:
 ```json
-{ "success": false, "error": { "code": <HTTP status code>, "message": "<description>" } }
+{ "success": false, "problemDetail": { "title": "<summary>", "status": <HTTP status code>, "detail": "<description>" } }
 ```
+Partial success responses (HTTP 206) MUST use `"success": true` with the standard `result` payload and an additional top-level `problemDetail` object:
+```json
+{ "success": true, "result": <data>, "problemDetail": { "title": "<summary>", "status": 206, "detail": "<description>" } }
+```
+Error objects MUST follow [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) (Problem Details for HTTP APIs), and include the following fields:
+ - `title` is a short human-readable summary of the problem type
+ - `status` is the HTTP status code
+ - `detail` is a human-readable explanation specific to this occurrence
 
 Implementations MAY support a Binary serialization for all responses, where the format of such response will be determined in a future RFC.
 

--- a/RFC for Contextualized Manufacturing Information API.md
+++ b/RFC for Contextualized Manufacturing Information API.md
@@ -81,7 +81,7 @@ When a client requests metadata, the server MUST return a `metadata` block along
 **Optional in the metadata block** — the server MAY include these where available:
 - description: a human-readable description conveying context or intent beyond what the DisplayName communicates
 - engUnit: the engineering unit for the element's value. Where present, definitions from [UNECE Recommendation Number 20](https://unece.org/trade/documents/2021/06/uncefact-rec20-0) MUST be used.
-- extendedAttributes: present only when `isExtended: true`. Contains non-conformant attributes and their inferred JSON Schema fragments, keyed by attribute name. Declared attributes are omitted — clients look those up from the ObjectType schema.
+- schemaExtensions: present only when `isExtended: true`. Contains non-conformant attributes and their inferred JSON Schema fragments, keyed by attribute name. Declared attributes are omitted — clients look those up from the ObjectType schema.
 - system: vendor-defined key/value pairs for platform-specific metadata not covered by standard fields. Values MUST be limited to strings, numbers, and booleans.
 
 ### 3.2 Object Relationships
@@ -182,7 +182,7 @@ If the ElementId exists as an instance object, this query MUST return the instan
 
 If an instance object differs from its Type definition, information about additional members is surfaced inline on all object responses via the `isExtended` and `extendedAttributes` fields defined in [section 3.1.1](#311-required-object-metadata).
 
-When `isExtended` is true and the client requests metadata, the response MUST include an `extendedAttributes` field containing the non-conformant attributes and their inferred JSON Schema fragments, keyed by attribute name. Declared (conformant) attributes are omitted from `extendedAttributes` — clients may look those up from the ObjectType schema identified by `typeElementId`.
+When `isExtended` is true and the client requests metadata, the response MUST include a `schemaExtensions` field containing the non-conformant attributes and their inferred JSON Schema fragments, keyed by attribute name. Declared (conformant) attributes are omitted from `schemaExtensions` — clients may look those up from the ObjectType schema identified by `typeElementId`.
 
 Implementations SHOULD resolve `allOf` inheritance chains in the declared type schema before determining conformance, so that inherited attributes are not incorrectly reported as extended.
 

--- a/RFC for Contextualized Manufacturing Information API.md
+++ b/RFC for Contextualized Manufacturing Information API.md
@@ -232,21 +232,19 @@ When invoked as a Query, the response MUST return a `values` array where each en
 
 Implementations MAY include the ability to write to the LastKnownValue. If this feature is implemented, the following considerations apply:
 
-When invoked as an Update, the LastKnownValue interface MUST accept a new current value for the requested object to be recorded, by ElementId. If the implementation supports write-back to a Control System (for example, via an interface to a PLC) additional security requirements outside the scope of this proposal MUST be considered.
+When invoked as an Update, the LastKnownValue interface MUST accept an array of `{elementId, value}` pairs in the request body. Each entry identifies the target Object by ElementId in the body (not in the URL path) and provides the new value in VQT format. If the implementation supports write-back to a Control System (for example, via an interface to a PLC) additional security requirements outside the scope of this proposal MUST be considered.
 
 Clients MUST write the complete value for the object. Partial attribute updates are not supported; the written value replaces the current value in its entirety.
 
-When invoked as an Update the LastKnownValue interface MAY accept an array of current values for an array of ElementIds.
+The response MUST use the bulk response envelope defined in [section 5.1.1](#511-response-serialization), with a per-item success or failure result for each ElementId in the request.
 
 ##### 4.2.2.2 Object Element HistoricalValue
 
 Implementations MAY include the ability to write to HistoricalValue(s). If this feature is implemented, the following considerations apply:
 
-When invoked as an Update, the HistoricalValue interface MUST accept an updated historical value for the requested object and timestamp, by ElementId.
+When invoked as an Update, the HistoricalValue interface MUST accept an array of `{elementId, value}` pairs in the request body. Each entry identifies the target Object by ElementId in the body (not in the URL path) and provides the value in VQT format. The `timestamp` field in the VQT identifies the historical record to create or replace.
 
-When invoked as an Update, the HistoricalValue interface MAY accept an array of updated historical values for an array of specified objects and timestamps, by ElementId.
-
-When invoked in order to Create a new historical record, the HistoricalValue interface MAY accept an array of new historical values for an array of specified objects and timestamps, by ElementId.
+The response MUST use the bulk response envelope defined in [section 5.1.1](#511-response-serialization), with a per-item success or failure result for each ElementId in the request.
 
 When updating Historical data, the implementation SHOULD implement auditing or tracking of such changes.
 

--- a/demo/server/app.py
+++ b/demo/server/app.py
@@ -14,6 +14,7 @@ from routers.namespaces import ns
 from routers.typeDefinitions import typeDefinitions
 from routers.objects import explore, query, update
 from routers.subscriptions import subs, subscription_worker, handle_data_source_update
+from routers.utils import _HTTP_TITLES
 from data_sources.factory import DataSourceFactory
 
 
@@ -164,7 +165,7 @@ app.add_middleware(
 async def http_exception_handler(request: Request, exc: HTTPException):
     return JSONResponse(
         status_code=exc.status_code,
-        content={"success": False, "error": {"code": exc.status_code, "message": exc.detail}}
+        content={"success": False, "problemDetail": {"title": _HTTP_TITLES.get(exc.status_code, "Error"), "status": exc.status_code, "detail": exc.detail}}
     )
 
 

--- a/demo/server/data_sources/mock/mock_data.py
+++ b/demo/server/data_sources/mock/mock_data.py
@@ -499,7 +499,7 @@ I3X_DATA = {
             # Example of an extended object: typed as temperature-sensor-type (which declares only
             # 'temperature' and 'unit'), but its value also carries vendor_serial and firmware_version
             # — attributes not in the declared schema. isExtended=true will be set on this object,
-            # and extendedAttributes will be populated when includeMetadata=true is requested.
+            # and schemaExtensions will be populated when includeMetadata=true is requested.
             "elementId": "sensor-003",
             "displayName": "TempSensor-VendorX",
             "typeElementId": "temperature-sensor-type",

--- a/demo/server/models.py
+++ b/demo/server/models.py
@@ -275,7 +275,7 @@ class ObjectInstanceMetadata(BaseModel):
     sourceTypeId: Optional[str] = None
     description: Optional[str] = None
     relationships: Optional[Dict[str, Any]] = None
-    extendedAttributes: Optional[Dict[str, Any]] = None
+    schemaExtensions: Optional[Dict[str, Any]] = None
     system: Optional[Dict[str, Any]] = None
 
 

--- a/demo/server/models.py
+++ b/demo/server/models.py
@@ -228,13 +228,14 @@ class GetRelationshipTypesRequest(ElementIdRequest):
 # --- Generic response wrappers ---
 
 class ErrorDetail(BaseModel):
-    code: int
-    message: str
+    title: str
+    status: int
+    detail: str
 
 
 class ErrorResponse(BaseModel):
     success: bool = False
-    error: ErrorDetail
+    problemDetail: ErrorDetail
 
 
 class SuccessResponse(BaseModel, Generic[T]):
@@ -247,7 +248,7 @@ class BulkResultItem(BaseModel, Generic[T]):
     elementId: Optional[str] = None
     subscriptionId: Optional[str] = None
     result: Optional[T] = None
-    error: Optional[ErrorDetail] = None
+    problemDetail: Optional[ErrorDetail] = None
 
 
 class BulkResponse(BaseModel, Generic[T]):

--- a/demo/server/models.py
+++ b/demo/server/models.py
@@ -108,31 +108,24 @@ class HistoricalValue(BaseModel):
     )
 
 
-# RFC 4.2.2.1 - Object Element LastKnownValue
-class UpdateRequest(BaseModel):
-    elementIds: List[str]
-    values: List[Any]
+# RFC 4.2.2.1 - Object Element LastKnownValue update
+class ValueUpdateItem(BaseModel):
+    elementId: str = Field(..., description="The elementId of the Object to update")
+    value: Any = Field(..., description="The VQT value to write. Must conform to the Object's type schema.")
 
 
-# TODO: the RFC doesn't say what this should be
-class UpdateResult(BaseModel):
-    elementId: str
-    success: bool
-    message: str
+class UpdateValueRequest(BaseModel):
+    updates: List[ValueUpdateItem] = Field(..., description="Array of elementId/value pairs to write")
 
 
-# 4.2.2.2 Object Element HistoricalValue
-class HistoricalValueUpdate(BaseModel):
-    elementId: str
-    timestamp: str  # ISO8601 string
-    value: Any
+# RFC 4.2.2.2 - Object Element HistoricalValue update
+class HistoryUpdateItem(BaseModel):
+    elementId: str = Field(..., description="The elementId of the Object to update")
+    value: VQT = Field(..., description="The VQT value to write, including timestamp")
 
 
-class HistoricalUpdateResult(BaseModel):
-    elementId: str
-    timestamp: str
-    success: bool
-    message: str
+class UpdateHistoryRequest(BaseModel):
+    updates: List[HistoryUpdateItem] = Field(..., description="Array of elementId/value pairs to write")
 
 
 class CreateSubscriptionRequest(BaseModel):

--- a/demo/server/routers/objects.py
+++ b/demo/server/routers/objects.py
@@ -1,12 +1,14 @@
-from fastapi import APIRouter, Path, Query, HTTPException, Body, Depends
+from fastapi import APIRouter, Query, HTTPException, Depends
 from fastapi.responses import JSONResponse
-from typing import Optional, Any, List
+from typing import Optional, List
 from urllib.parse import unquote
 from models import (
     GetObjectsRequest,
     GetRelatedObjectsRequest,
     GetObjectValueRequest,
     GetObjectHistoryRequest,
+    UpdateValueRequest,
+    UpdateHistoryRequest,
     SuccessResponse,
     BulkResponse,
     ErrorResponse,
@@ -200,84 +202,56 @@ def query_historical_values(
     return response_body
 
 
-# RFC 4.2.1.2 - Historical values for a single Object (convenience GET form)
-@query.get(
-    "/objects/{elementId}/history",
-    summary="Get Historical Values",
-    operation_id="getHistoricalValues",
-    response_model=SuccessResponse[HistoricalValueResult],
-    responses={206: {"model": SuccessResponse[HistoricalValueResult], "description": PARTIAL_CONTENT_DESCRIPTION}, **NOT_FOUND_RESPONSE, **BASE_ERROR_RESPONSES},
-)
-def get_historical_values(
-    elementId: str = Path(...),
-    startTime: Optional[str] = Query(default=None, description="ISO 8601 start time"),
-    endTime: Optional[str] = Query(default=None, description="ISO 8601 end time"),
-    maxDepth: int = Query(default=1, ge=0, description="Recursion depth through HasComponent. 0=infinite, 1=no recursion"),
-    data_source=Depends(get_data_source),
-):
-    """Return historical values for a single Object. Optionally filter by time range."""
-    elementId = unquote(elementId)
-    instance = data_source.get_instance_by_id(elementId)
-    if not instance:
-        raise HTTPException(status_code=404, detail=f"Element not found: {elementId}")
-
-    historical_values = data_source.get_instance_values_by_id(
-        elementId,
-        startTime,
-        endTime,
-        maxDepth,
-        returnHistory=True,
-    )
-    if not historical_values:
-        raise HTTPException(status_code=404, detail="No historical data available")
-
-    transformed, was_truncated = transform_value_result(elementId, historical_values, instance, is_history=True)
-    if transformed is None:
-        raise HTTPException(status_code=404, detail="No historical data available")
-
-    if was_truncated:
-        return JSONResponse(content={"success": True, "result": transformed}, status_code=206)
-    return {"success": True, "result": transformed}
-
-
 # RFC 4.2.2.1 - Object Element LastKnownValue update
-@update.put(
-    "/objects/{elementId}/value",
-    summary="Update Value of Object",
-    operation_id="updateObjectValue",
-    response_model=SuccessResponse[None],
-    responses={**NOT_FOUND_RESPONSE, **BASE_ERROR_RESPONSES},
+@update.post(
+    "/objects/value/update",
+    summary="Update Values of Objects",
+    operation_id="updateObjectValues",
+    response_model=BulkResponse[None],
+    responses={**BASE_ERROR_RESPONSES},
 )
-def update_object(
-    elementId: str = Path(...),
-    body: Any = Body(...),
+def update_object_values(
+    request_body: UpdateValueRequest,
     data_source=Depends(get_data_source),
 ):
-    """Update the value of an Object"""
-    if not data_source.get_instance_by_id(elementId):
-        raise HTTPException(status_code=404, detail=f"Element not found: {elementId}")
-    try:
-        # Unwrap VQT body: {value, quality, timestamp} -> extract inner value
-        if isinstance(body, dict) and "value" in body:
-            value = body["value"]
-        else:
-            value = body
-        data_source.update_instance_value(elementId, value)
-        return success_response(None)
-    except Exception as e:
-        return error_response(str(e))
+    """
+    Update the current value of one or more Objects.
+
+    Request body: {"updates": [{"elementId": "...", "value": {...}}, ...]}
+
+    Returns bulk response with succeeded/failed per elementId.
+    """
+    results = []
+    for item in request_body.updates:
+        eid = unquote(item.elementId)
+        instance = data_source.get_instance_by_id(eid)
+        if not instance:
+            results.append({"success": False, "elementId": eid, "problemDetail": {"title": "Not Found", "status": 404, "detail": f"Element not found: {eid}"}})
+            continue
+        try:
+            body = item.value
+            value = body["value"] if isinstance(body, dict) and "value" in body else body
+            data_source.update_instance_value(eid, value)
+            results.append({"success": True, "elementId": eid, "result": None})
+        except Exception as e:
+            results.append({"success": False, "elementId": eid, "problemDetail": {"title": "Error", "status": 500, "detail": str(e)}})
+    return bulk_response(results)
 
 
-# RFC 4.2.2.2 - Object Element HistoricalValue
-@update.put(
-    "/objects/{elementId}/history",
-    summary="Update Historical Values of Object",
+# RFC 4.2.2.2 - Object Element HistoricalValue update
+@update.post(
+    "/objects/history/update",
+    summary="Update Historical Values of Objects",
     operation_id="updateObjectHistory",
-    responses={501: {"model": ErrorResponse, "description": "Not Implemented — optional feature not supported by this server"}, **NOT_FOUND_RESPONSE, **BASE_ERROR_RESPONSES},
+    responses={501: {"model": ErrorResponse, "description": "Not Implemented — optional feature not supported by this server"}, **BASE_ERROR_RESPONSES},
 )
 def update_object_history(
-    elementId: str = Path(...),
+    request_body: UpdateHistoryRequest,
     data_source=Depends(get_data_source),
 ):
-    """Update the historical values for one or more Objects"""
+    """
+    Update historical values for one or more Objects.
+
+    Request body: {"updates": [{"elementId": "...", "value": {"value": ..., "quality": "...", "timestamp": "..."}}, ...]}
+    """
     raise HTTPException(status_code=501, detail="Operation not implemented")

--- a/demo/server/routers/objects.py
+++ b/demo/server/routers/objects.py
@@ -63,7 +63,7 @@ def query_objects_by_id(
             extra_attrs = data_source.get_instance_extra_attributes(eid_decoded)
             results.append({"success": True, "elementId": eid_decoded, "result": getObject(instance, request_body.includeMetadata, type_info, extra_attrs)})
         else:
-            results.append({"success": False, "elementId": eid_decoded, "error": {"code": 404, "message": f"Element not found: {eid_decoded}"}})
+            results.append({"success": False, "elementId": eid_decoded, "problemDetail": {"title": "Not Found", "status": 404, "detail": f"Element not found: {eid_decoded}"}})
 
     return bulk_response(results)
 
@@ -103,7 +103,7 @@ def query_related_objects(
                 })
             results.append({"success": True, "elementId": eid_decoded, "result": related_result})
         else:
-            results.append({"success": False, "elementId": eid_decoded, "error": {"code": 404, "message": f"Element not found: {eid_decoded}"}})
+            results.append({"success": False, "elementId": eid_decoded, "problemDetail": {"title": "Not Found", "status": 404, "detail": f"Element not found: {eid_decoded}"}})
 
     return bulk_response(results)
 
@@ -143,9 +143,9 @@ def query_last_known_values(
                     any_truncated = True
                 results.append({"success": True, "elementId": eid_decoded, "result": transformed})
             else:
-                results.append({"success": False, "elementId": eid_decoded, "error": {"code": 404, "message": "No value available"}})
+                results.append({"success": False, "elementId": eid_decoded, "problemDetail": {"title": "Not Found", "status": 404, "detail": "No value available"}})
         else:
-            results.append({"success": False, "elementId": eid_decoded, "error": {"code": 404, "message": f"Element not found: {eid_decoded}"}})
+            results.append({"success": False, "elementId": eid_decoded, "problemDetail": {"title": "Not Found", "status": 404, "detail": f"Element not found: {eid_decoded}"}})
 
     response_body = bulk_response(results)
     if any_truncated:
@@ -190,9 +190,9 @@ def query_historical_values(
                     any_truncated = True
                 results.append({"success": True, "elementId": eid_decoded, "result": transformed})
             else:
-                results.append({"success": False, "elementId": eid_decoded, "error": {"code": 404, "message": "No historical data available"}})
+                results.append({"success": False, "elementId": eid_decoded, "problemDetail": {"title": "Not Found", "status": 404, "detail": "No historical data available"}})
         else:
-            results.append({"success": False, "elementId": eid_decoded, "error": {"code": 404, "message": f"Element not found: {eid_decoded}"}})
+            results.append({"success": False, "elementId": eid_decoded, "problemDetail": {"title": "Not Found", "status": 404, "detail": f"Element not found: {eid_decoded}"}})
 
     response_body = bulk_response(results)
     if any_truncated:

--- a/demo/server/routers/subscriptions.py
+++ b/demo/server/routers/subscriptions.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, HTTPException, Request
-from fastapi.responses import StreamingResponse
+from fastapi.responses import StreamingResponse, JSONResponse
 from typing import List, Optional, Any, Callable, Dict
 from datetime import datetime, timezone
 import asyncio
@@ -21,6 +21,8 @@ from models import (
 )
 from .utils import getSubscriptionValue, success_response, bulk_response, get_data_source, BASE_ERROR_RESPONSES, NOT_FOUND_RESPONSE
 
+PARTIAL_CONTENT_DESCRIPTION = "Some updates were dropped from the subscription queue due to overflow. See the `detail` field in the response body."
+
 
 # Not required, but showing what information is stored for simulated subscriptions
 class Subscription(BaseModel):
@@ -33,6 +35,7 @@ class Subscription(BaseModel):
     max_queue_size: int = 1000
     nextSequence: int = 1           # Sequence number for the next queued update
     lastAckedSequence: int = 0      # Highest sequence number acknowledged by the client
+    droppedCount: int = 0           # Updates dropped from the queue since last client ack
     ttl_seconds: int = 300          # Idle TTL: subscription auto-deleted if no /sync or active stream within this window
     last_activity: str = ""         # ISO timestamp of last /sync, /ack, or stream open
     is_streaming: bool = False  # True when SSE connection is active
@@ -108,7 +111,7 @@ def register_objects(request: Request, req: RegisterMonitoredItemsRequest):
 
     for eid in req.elementIds:
         if not data_source.get_instance_by_id(eid):
-            results.append({"success": False, "elementId": eid, "error": {"code": 404, "message": f"Element not found: {eid}"}})
+            results.append({"success": False, "elementId": eid, "problemDetail": {"title": "Not Found", "status": 404, "detail": f"Element not found: {eid}"}})
             continue
         tree = collect_instance_tree(eid, req.maxDepth, 0, data_source.get_all_instances())
         for item in tree:
@@ -139,7 +142,7 @@ def unregister_objects(request: Request, req: RegisterMonitoredItemsRequest):
 
     for eid in req.elementIds:
         if not data_source.get_instance_by_id(eid):
-            results.append({"success": False, "elementId": eid, "error": {"code": 404, "message": f"Element not found: {eid}"}})
+            results.append({"success": False, "elementId": eid, "problemDetail": {"title": "Not Found", "status": 404, "detail": f"Element not found: {eid}"}})
             continue
         tree = collect_instance_tree(eid, req.maxDepth, 0, data_source.get_all_instances())
         for item in tree:
@@ -210,13 +213,18 @@ async def stream_subscription(request: Request, req: StreamRequest):
     summary="Sync Values",
     operation_id="syncSubscription",
     response_model=SuccessResponse[List[SyncUpdate]],
-    responses={**NOT_FOUND_RESPONSE, **BASE_ERROR_RESPONSES},
+    responses={
+        206: {"description": PARTIAL_CONTENT_DESCRIPTION},
+        **NOT_FOUND_RESPONSE,
+        **BASE_ERROR_RESPONSES,
+    },
 )
 def sync_subscription(request: Request, req: SyncRequest):
     """Acknowledge previously received updates and return all pending updates in one call.
 
     If `lastSequenceNumber` is provided, all queued updates with sequenceNumber <= lastSequenceNumber are removed first,
-    then the remaining (newer) updates are returned. subscriptionId is passed in the request body.
+    then the remaining (newer) updates are returned. Returns HTTP 206 if updates were dropped from the queue since
+    the client's last acknowledged sequence number. subscriptionId is passed in the request body.
     """
     sub = _find_sub(request, req.subscriptionId, req.clientId)
     if not sub:
@@ -226,8 +234,36 @@ def sync_subscription(request: Request, req: SyncRequest):
         sub.pendingUpdates = [u for u in sub.pendingUpdates if u.get("sequenceNumber", 0) > req.lastSequenceNumber]
         sub.lastAckedSequence = max(sub.lastAckedSequence, req.lastSequenceNumber)
 
+    # Detect data loss: explicit drop counter or a sequence gap between the last ack and first available update
+    has_drops = sub.droppedCount > 0
+    if not has_drops and sub.pendingUpdates and req.lastSequenceNumber is not None:
+        first_seq = sub.pendingUpdates[0].get("sequenceNumber", 0)
+        has_drops = first_seq > req.lastSequenceNumber + 1
+
+    # Reset drop counter now that the client is being informed
+    sub.droppedCount = 0
+
     sub.last_activity = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-    return success_response(list(sub.pendingUpdates))
+    updates = list(sub.pendingUpdates)
+
+    if has_drops:
+        body = {
+            "success": True,
+            "result": updates,
+            "problemDetail": {
+                "title": "Updates dropped due to queue overflow",
+                "status": 206,
+                "detail": (
+                    "Updates were dropped from the subscription queue because the server-imposed "
+                    "queue limit was reached. The client may assume that all sequence numbers "
+                    "between its last acknowledged sequence number and the first returned sequence "
+                    "number were dropped."
+                ),
+            },
+        }
+        return JSONResponse(content=body, status_code=206)
+
+    return success_response(updates)
 
 
 # POST /subscriptions/delete - Delete one or more subscriptions
@@ -256,7 +292,7 @@ def delete_subscriptions(request: Request, req: DeleteSubscriptionsRequest):
             request.app.state.I3X_DATA_SUBSCRIPTIONS.pop(index)
             results.append({"success": True, "subscriptionId": sub_id, "result": None})
         else:
-            results.append({"success": False, "subscriptionId": sub_id, "error": {"code": 404, "message": f"Subscription not found: {sub_id}"}})
+            results.append({"success": False, "subscriptionId": sub_id, "problemDetail": {"title": "Not Found", "status": 404, "detail": f"Subscription not found: {sub_id}"}})
 
     return bulk_response(results)
 
@@ -286,7 +322,7 @@ def list_subscriptions(request: Request, req: ListSubscriptionsRequest):
                 },
             })
         else:
-            results.append({"success": False, "subscriptionId": sub_id, "error": {"code": 404, "message": f"Subscription not found: {sub_id}"}})
+            results.append({"success": False, "subscriptionId": sub_id, "problemDetail": {"title": "Not Found", "status": 404, "detail": f"Subscription not found: {sub_id}"}})
 
     return bulk_response(results)
 
@@ -325,9 +361,10 @@ def handle_data_source_update(instance, value, I3X_DATA_SUBSCRIPTIONS, data_sour
                         **update_value,
                     }
                     sub.nextSequence += 1
-                    # Enforce FIFO with max queue size
+                    # Enforce FIFO with max queue size — oldest update is dropped first
                     if len(sub.pendingUpdates) >= sub.max_queue_size:
                         sub.pendingUpdates.pop(0)
+                        sub.droppedCount += 1
                     sub.pendingUpdates.append(queued_item)
     except Exception as e:
         import traceback

--- a/demo/server/routers/typeDefinitions.py
+++ b/demo/server/routers/typeDefinitions.py
@@ -52,7 +52,7 @@ def query_object_types_by_id(
         if obj_type:
             results.append({"success": True, "elementId": eid_decoded, "result": formatObjectType(obj_type)})
         else:
-            results.append({"success": False, "elementId": eid_decoded, "error": {"code": 404, "message": f"Object type not found: {eid_decoded}"}})
+            results.append({"success": False, "elementId": eid_decoded, "problemDetail": {"title": "Not Found", "status": 404, "detail": f"Object type not found: {eid_decoded}"}})
 
     return bulk_response(results)
 
@@ -95,6 +95,6 @@ def query_relationship_types_by_id(
         if rel_type:
             results.append({"success": True, "elementId": eid_decoded, "result": rel_type})
         else:
-            results.append({"success": False, "elementId": eid_decoded, "error": {"code": 404, "message": f"Relationship type not found: {eid_decoded}"}})
+            results.append({"success": False, "elementId": eid_decoded, "problemDetail": {"title": "Not Found", "status": 404, "detail": f"Relationship type not found: {eid_decoded}"}})
 
     return bulk_response(results)

--- a/demo/server/routers/utils.py
+++ b/demo/server/routers/utils.py
@@ -76,7 +76,7 @@ def getObject(instance: Any, includeMetadata: bool, type_info: Any = None, extra
     metadata["relationships"] = instance.get("relationships", {})
 
     if extra_attrs:
-        metadata["extendedAttributes"] = extra_attrs
+        metadata["schemaExtensions"] = extra_attrs
 
     # Collect vendor/server-defined instance-level properties (RFC 3.1.2 optional metadata)
     # into metadata.system. Values are limited to primitives (string, number, boolean).

--- a/demo/server/routers/utils.py
+++ b/demo/server/routers/utils.py
@@ -5,7 +5,7 @@ from models import ErrorResponse
 
 # Shared response schema dicts for use in route decorators
 BASE_ERROR_RESPONSES = {
-    "default": {"model": ErrorResponse, "description": "Error — see error.code for the HTTP status code (400, 401, 403, 404, 500, etc.)"},
+    "default": {"model": ErrorResponse, "description": "Error — see problemDetail.code for the HTTP status code (400, 401, 403, 404, 500, etc.)"},
 }
 
 NOT_FOUND_RESPONSE = {
@@ -32,8 +32,14 @@ def success_response(result):
     return {"success": True, "result": result}
 
 
-def error_response(message, code=500):
-    return {"success": False, "error": {"code": code, "message": message}}
+_HTTP_TITLES = {
+    400: "Bad Request", 401: "Unauthorized", 403: "Forbidden",
+    404: "Not Found", 500: "Internal Server Error", 501: "Not Implemented",
+}
+
+def error_response(detail, status=500):
+    title = _HTTP_TITLES.get(status, "Error")
+    return {"success": False, "problemDetail": {"title": title, "status": status, "detail": detail}}
 
 
 def bulk_response(results):

--- a/spec/IMPLEMENTATION_GUIDE.md
+++ b/spec/IMPLEMENTATION_GUIDE.md
@@ -132,8 +132,8 @@ Examples:
 // POST /subscriptions
 { "success": true, "result": { "subscriptionId": "Xf9q8wL1...", "displayName": "mySubscription" } }
 
-// PUT /objects/{elementId}/value (write succeeded)
-{ "success": true, "result": null }
+// POST /objects/value/update (write succeeded)
+{ "success": true, "results": [{ "success": true, "elementId": "pump-101", "result": null }] }
 ```
 
 ### Failure
@@ -510,8 +510,8 @@ Returns the server version and capabilities. Clients SHOULD call this endpoint b
 | `serverName`                    | string | No | Human-readable name for this server or deployment                  |
 | `capabilities`                       | object | Yes | Declares which optional features this server supports              |
 | `capabilities.query.history`         | boolean | Yes | True if `POST /objects/history` is supported                       |
-| `capabilities.update.current`        | boolean | Yes | True if `PUT /objects/{elementId}/value` is supported              |
-| `capabilities.update.history`        | boolean | Yes | True if `PUT /objects/{elementId}/history` is supported            |
+| `capabilities.update.current`        | boolean | Yes | True if `POST /objects/value/update` is supported              |
+| `capabilities.update.history`        | boolean | Yes | True if `POST /objects/history/update` is supported            |
 | `capabilities.subscribe.stream`      | boolean | Yes | True if `POST /subscriptions/stream` is supported                  |
 
 
@@ -1209,15 +1209,9 @@ It is the responsibility of the implementing platform to validate the input, inc
 
 ---
 
-#### `PUT` /objects/{elementId}/value
+#### `POST` /objects/value/update
 
-Update the value of an Object.
-
-**Path Parameters:**
-
-| Name | Type | Required | Description |
-|------|------|----------|-------------|
-| `elementId` | string | Yes | The elementId of the Object to update |
+Update the current value of one or more Objects.
 
 **Request Body:**
 
@@ -1225,49 +1219,87 @@ The value to write in VQT format. The value will replace the current Object valu
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `value` | any | Yes | The data value to write. Must conform to the Object's type schema. `null` is permitted for nullable fields — see [Null Value Handling](#null-value-handling). |
-| `quality` | string | No | Quality indicator. Defaults to `"Good"` if omitted. |
-| `timestamp` | string | No | RFC 3339 timestamp. Defaults to server time if omitted. |
+| `updates` | array | Yes | Array of elementId/value pairs to write |
+| `updates[].elementId` | string | Yes | The elementId of the Object to update |
+| `updates[].value` | object | Yes | The VQT value to write. `value` must conform to the Object's type schema. `null` is permitted for nullable fields — see [Null Value Handling](#null-value-handling). |
+| `updates[].value.value` | any | Yes | The data value to write |
+| `updates[].value.quality` | string | No | Quality indicator. Defaults to `"Good"` if omitted. |
+| `updates[].value.timestamp` | string | No | RFC 3339 timestamp. Defaults to server time if omitted. |
 
 ```json
 {
-  "value": { "temperature": 20, "unit": "C" },
-  "quality": "Good",
-  "timestamp": "2025-01-08T10:30:00Z"
+  "updates": [
+    {
+      "elementId": "pump-101",
+      "value": {
+        "value": { "temperature": 20, "unit": "C" },
+        "quality": "Good",
+        "timestamp": "2025-01-08T10:30:00Z"
+      }
+    }
+  ]
 }
 ```
 
 **Response:**
 
+Returns a bulk response with a result per elementId.
+
 ```json
 {
   "success": true,
-  "result": null
+  "results": [
+    { "success": true, "elementId": "pump-101", "result": null },
+    { "success": false, "elementId": "bad-id", "problemDetail": { "title": "Not Found", "status": 404, "detail": "Element not found: bad-id" } }
+  ]
 }
 ```
 
 ---
 
-#### `PUT` /objects/{elementId}/history
+#### `POST` /objects/history/update
 
-Update historical values of an Object.
+Update historical values of one or more Objects.
 
-**Path Parameters:**
-
-| Name | Type | Required | Description |
-|------|------|----------|-------------|
-| `elementId` | string | Yes | The elementId of the Object to update |
+> **Note:** This endpoint is defined by the specification but not yet implemented by this server. It returns HTTP 501.
 
 **Request Body:**
 
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `updates` | array | Yes | Array of elementId/value pairs to write |
+| `updates[].elementId` | string | Yes | The elementId of the Object to update |
+| `updates[].value` | object | Yes | A VQT object. The `timestamp` field identifies which historical record to create or replace. |
+| `updates[].value.value` | any | Yes | The data value to write |
+| `updates[].value.quality` | string | Yes | Quality indicator |
+| `updates[].value.timestamp` | string | Yes | RFC 3339 timestamp of the historical record to write |
+
 ```json
-// TODO document this
+{
+  "updates": [
+    {
+      "elementId": "pump-101",
+      "value": {
+        "value": { "temperature": 19.5, "unit": "C" },
+        "quality": "Good",
+        "timestamp": "2025-01-07T08:00:00Z"
+      }
+    }
+  ]
+}
 ```
 
 **Response:**
 
+Returns a bulk response with a result per elementId.
+
 ```json
-// TODO document this
+{
+  "success": true,
+  "results": [
+    { "success": true, "elementId": "pump-101", "result": null }
+  ]
+}
 ```
 
 ---

--- a/spec/IMPLEMENTATION_GUIDE.md
+++ b/spec/IMPLEMENTATION_GUIDE.md
@@ -757,7 +757,7 @@ Returns a list of all Objects, optionally filtered by `typeElementId`. This allo
           "HasParent": "/",
           "HasChildren": ["child1", "child2"]
         },
-        "extendedAttributes": {
+        "schemaExtensions": {
           "serial_number": { "type": "string" },
           "firmware_version": { "type": "string" }
         },
@@ -779,7 +779,7 @@ Returns a list of all Objects, optionally filtered by `typeElementId`. This allo
 | `typeElementId` | string  | Yes      | ElementId of the Object Type that defines this Object's schema                                                                                                                                                         |
 | `parentId`      | string? | Yes      | ElementId of the parent Object in the organizational hierarchy; `null` if this is a root Object                                                                                                                        |
 | `isComposition` | boolean | Yes      | `true` if this Object encapsulates composed child elements (HasComponent). Composition children contribute to the parent's value and are returned together under `components` when reading values with `maxDepth > 1`. |
-| `isExtended`    | boolean | Yes      | `true` if the Object's current value contains attributes not declared in its ObjectType schema. The Object carries data the type doesn't describe. See `extendedAttributes` below in the `metadata`.                   |
+| `isExtended`    | boolean | Yes      | `true` if the Object's current value contains attributes not declared in its ObjectType schema. The Object carries data the type doesn't describe. See `schemaExtensions` below in the `metadata`.                   |
 
 The `metadata` key is included if `includeMetadata=true` in the request.
 
@@ -789,7 +789,7 @@ The `metadata` key is included if `includeMetadata=true` in the request.
 | `metadata.typeNamespaceUri`   | string  | Yes                      | The namespace the ObjectType *definition* belongs to — identifies which namespace's schema this Object conforms to (e.g., an ISA-95 or OPC UA standard namespace, or a vendor namespace). An Object instance's type may come from any namespace; this field makes that provenance explicit. For example, if the external Namespace was the OPC UA for Machinery Companion spec, the typeNamespaceUri would be `http://opcfoundation.org/UA/Machinery/`. |
 | `metadata.sourceTypeId`       | string  | Yes                      | An identifier of this type within its *source namespace*. Provided so clients can correlate back to the originating definition. Distinct from `typeElementId`, which is the i3X address space identifier. For example, if the external Type was JobOrderControl from the OPC UA for Machinery Companion spec, the typeElementId may be the BrowseName, `JobOrderControl` OR the NodeId `ns=1;i=5058`. |
 | `metadata.relationships`      | object  | No                       | The Object's outgoing relationship edges, keyed by relationship type. Enables clients to plan graph traversal without an additional `/objects/related` call. Only elementIds are returned here; use `/objects/related` to get the full related Object records. |
-| `metadata.extendedAttributes` | object  | No                       | Present only when `isExtended=true`. Contains the non-conformant attributes and their inferred JSON Schema fragments, keyed by attribute name. Declared (conformant) attributes are omitted — they can be looked up from the `typeElementId`. |
+| `metadata.schemaExtensions` | object  | No                       | Present only when `isExtended=true`. Contains the non-conformant attributes and their inferred JSON Schema fragments, keyed by attribute name. Declared (conformant) attributes are omitted — they can be looked up from the `typeElementId`. |
 |  `metadata.system`            | object | Yes if `isExtended=true` | Vendor-defined key/value pairs for platform-specific metadata not covered by the standard fields. Keys are vendor-defined strings; values are limited to strings, numbers, and booleans.|
 
 

--- a/spec/IMPLEMENTATION_GUIDE.md
+++ b/spec/IMPLEMENTATION_GUIDE.md
@@ -36,6 +36,7 @@ This document is a working draft, and should not be considered complete or norma
   - [Registering and Unregistering Objects](#registering-and-unregistering-objects)
   - [Streaming](#streaming)
   - [Sync](#sync)
+    - [Queue Overflow and Partial Responses](#queue-overflow-and-partial-responses)
   - [Subscription Life Cycle](#subscription-life-cycle)
 - [Appendix](#appendix-for-now)
   - [Relationship Semantics](#relationship-semantics)
@@ -137,42 +138,44 @@ Examples:
 
 ### Failure
 
-Failures return an HTTP error code with the following shape.
+Failures return an HTTP error code with the following shape. The `problemDetail` object follows [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) (Problem Details for HTTP APIs).
 
 ```json
 {
   "success": false,
-  "error": {
-    "code": 400,
-    "message": "error message"
+  "problemDetail": {
+    "title": "Not Found",
+    "status": 404,
+    "detail": "Element not found: pump-101"
   }
 }
 ```
 
-| Field        | Type    | Required | Description                                                           |
-|--------------|---------|----------|-----------------------------------------------------------------------|
-| `success`    | boolean | Yes      | False if the request is not successful. HTTP return must be none 200. |
-| `error.code` | Number  | Yes      | The HTTP error code.                                                  |
-| `error.message` | String  | Yes      | Server specific error message to add context for the caller.          |
+| Field                    | Type    | Required | Description                                                             |
+|--------------------------|---------|----------|-------------------------------------------------------------------------|
+| `success`                | boolean | Yes      | `false` for any error response.                                         |
+| `problemDetail.title`    | string  | Yes      | Short, human-readable summary of the problem type (e.g. `"Not Found"`). |
+| `problemDetail.status`   | number  | Yes      | The HTTP status code.                                                   |
+| `problemDetail.detail`   | string  | Yes      | Human-readable explanation specific to this occurrence.                 |
 
-The following HTTP error codes are suggested.
+The following HTTP status codes are used.
 
 | Code | Meaning | When to Use |
 |------|---------|-------------|
 | 200 | OK | Successful request |
-| 206 | Partial Content | Server fulfilled part of the request due to server-imposed limits (e.g., depth cap on a composition query) |
+| 206 | Partial Content | Server fulfilled part of the request due to server-imposed limits. The response body includes a top-level `problemDetail` object. |
 | 400 | Bad Request | Invalid parameters, malformed request body, or request the server cannot fulfill at all |
 | 401 | Unauthorized | Missing or invalid authentication |
 | 403 | Forbidden | Authenticated but not authorized |
 | 404 | Not Found | ElementId or resource doesn't exist |
 | 500 | Internal Server Error | Server-side error |
-| 501 | Not Implemented | Optional feature not supported 
+| 501 | Not Implemented | Optional feature not supported
 
 Examples:
 
 ```json
 // GET /namespaces
-{ "success": false, "error": { "code": 401, "message": "User does not have access"}}
+{ "success": false, "problemDetail": { "title": "Unauthorized", "status": 401, "detail": "User does not have access" }}
 ```
 
 ### Bulk Response
@@ -193,9 +196,10 @@ The Server's response MUST be in the same order and the same size as the request
     {
       "success": false,
       "elementId": "non-existent",
-      "error": {
-        "code": 404,
-        "message": "Element not found: non-existent"
+      "problemDetail": {
+        "title": "Not Found",
+        "status": 404,
+        "detail": "Element not found: non-existent"
       }
     }
   ]
@@ -617,9 +621,10 @@ Returns one or more Object Types given a collection of elementIds.
     {
       "success": false,
       "elementId": "string",
-      "error": { 
-        "code": 404,
-        "message": "Object type not found: string"
+      "problemDetail": {
+        "title": "Not Found",
+        "status": 404,
+        "detail": "Object type not found: string"
       }
     }
   ]
@@ -705,9 +710,10 @@ Returns one or more Relationship Types given a collection of elementIds.
     {
       "success": false,
       "elementId": "string",
-      "error": { 
-        "code": 404,
-        "message": "Relationship type not found: string"
+      "problemDetail": {
+        "title": "Not Found",
+        "status": 404,
+        "detail": "Relationship type not found: string"
       }
     }
   ]
@@ -832,9 +838,10 @@ Returns one or more Objects without data/values given a collection of elementIds
     {
       "success": false,
       "elementId": "string",
-      "error": {
-        "code": 404,
-        "message": "Element not found: string"
+      "problemDetail": {
+        "title": "Not Found",
+        "status": 404,
+        "detail": "Element not found: string"
       }
     }
   ]
@@ -871,9 +878,10 @@ Returns one or more Objects without data/values given a collection of elementIds
     {
       "success": false,
       "elementId": "string",
-      "error": { 
-        "code": 404,
-        "message": "Element not found: string"
+      "problemDetail": {
+        "title": "Not Found",
+        "status": 404,
+        "detail": "Element not found: string"
       }
     }
   ]
@@ -935,9 +943,10 @@ Returns a bulk response with the related Objects for each queried elementId.
     {
       "success": false,
       "elementId": "string",
-      "error": { 
-        "code": 404,
-        "message": "Element not found: string"
+      "problemDetail": {
+        "title": "Not Found",
+        "status": 404,
+        "detail": "Element not found: string"
       }
     }
   ]
@@ -1090,9 +1099,10 @@ Returns the last known value for one or more Objects.
     {
       "success": false,
       "elementId": "string",
-      "error": { 
-        "code": 404,
-        "message": "Element not found: string"
+      "problemDetail": {
+        "title": "Not Found",
+        "status": 404,
+        "detail": "Element not found: string"
       }
     }
   ]
@@ -1174,9 +1184,10 @@ Returns the historical values for one or more Objects between a start and end ti
     {
       "success": false,
       "elementId": "string",
-      "error": { 
-        "code": 404,
-        "message": "Element not found: string"
+      "problemDetail": {
+        "title": "Not Found",
+        "status": 404,
+        "detail": "Element not found: string"
       }
     }
   ]
@@ -1564,6 +1575,42 @@ Sync allows the client to control when value changes are received, and to explic
 
 This approach ensures updates are not lost if the client crashes between receiving and processing data, while keeping acknowledgement and polling as a single call.
 
+#### Queue Overflow and Partial Responses
+
+Servers maintain a queue for each subscription. When the queue is full and a new update arrives, the server MUST drop the oldest pending update to make room. If a client polls infrequently relative to the rate of change, it may miss updates.
+
+When the server has dropped updates since the client's last acknowledged sequence number, it MUST return **HTTP 206 (Partial Content)**. The response body has the same shape as a normal 200, with one addition: a `problemDetail` object:
+
+```json
+HTTP 206
+{
+  "success": true,
+  "result": [
+    {"sequenceNumber": 151, "elementId": "sensor-001", "value": 72.5, "quality": "Good", "timestamp": "2025-01-08T10:30:01Z"}
+  ],
+  "problemDetail": {
+    "title": "Updates dropped due to queue overflow",
+    "status": 206,
+    "detail": "Updates were dropped from the subscription queue because the server-imposed queue limit was reached. The client may assume that all sequence numbers between its last acknowledged sequence number and the first returned sequence number were dropped."
+  }
+}
+```
+
+**Inferring dropped sequence numbers:**
+
+The `sequenceNumber` on each update is monotonically increasing per update for a given subscription. When receiving an HTTP 206 response, a client can determine exactly which updates were lost by inspecting the :
+
+> All sequence numbers between `lastSequenceNumber + 1` and `result[0].sequenceNumber - 1` were dropped.
+
+For example, if the client's last call used `"lastSequenceNumber": 100` and the first update in the 206 response has `"sequenceNumber": 151`, then the 50 updates with sequence numbers 101–150 are permanently gone.
+
+**Client requirements on 206:**
+
+- Clients MUST process returned updates in the `result` array normally
+- Clients MUST continue polling with the highest returned `sequenceNumber` as the next `lastSequenceNumber`
+- Clients MUST NOT attempt to retrieve dropped updates — they are no longer unavailable
+- Clients SHOULD log or raise an alert when a 206 is received, as it indicates data loss
+
 ---
 
 #### `POST` /subscriptions/sync
@@ -1601,7 +1648,7 @@ All subsequent calls (ack previous batch, fetch new):
 }
 ```
 
-**Response:**
+**Response (HTTP 200 — all updates delivered):**
 
 ```json
 {
@@ -1612,6 +1659,24 @@ All subsequent calls (ack previous batch, fetch new):
   ]
 }
 ```
+
+**Response (HTTP 206 — some updates were dropped):**
+
+```json
+{
+  "success": true,
+  "result": [
+    {"sequenceNumber": 151, "elementId": "sensor-001", "value": 74.1, "quality": "Good", "timestamp": "2025-01-08T10:35:00Z"}
+  ],
+  "problemDetail": {
+    "title": "Updates dropped due to queue overflow",
+    "status": 206,
+    "detail": "Updates were dropped from the subscription queue because the server-imposed queue limit was reached. The client may assume that all sequence numbers between its last acknowledged sequence number and the first returned sequence number were dropped."
+  }
+}
+```
+
+See [Queue Overflow and Partial Responses](#queue-overflow-and-partial-responses) for how to interpret a 206 response and recover from data loss.
 
 ---
 


### PR DESCRIPTION
Remove single-element GET/PUT path endpoints; replace with POST body equivalents to address #296

### Problem
ElementIds can contain URL-special characters (slashes, colons, query separators, etc.). Encoding them into URL path segments is challenging for clients - the existing unquote() workaround is a band-aid, not a solution.

### Proposed Solution

**Removed:**
- `GET /objects/{elementId}/history` — redundant with the existing POST /objects/history (same capability, already bulk-capable)
- `PUT /objects/{elementId}/value` — _replaced_ with POST defined below   
- `PUT /objects/{elementId}/history` — _replaced_ with the correct endpoint shape defined below for when the feature is implemented

**Added:**
- `POST /objects/value/update` — writes current values; accepts elementIds in the request body
- `POST /objects/history/update` — writes historical values; accepts elementIds in the request body (returns 501 until implemented)

Request shape (match with all other bulk endpoints): 
``` 
  {
    "updates": [
      { "elementId": "...", "value": { "value": ..., "quality": "Good", "timestamp": "..." } } 
    ]
  }
```

Response shape — match bulk envelope used everywhere else:
```
  { 
    "success": true,
    "results": [
      { "success": true, "elementId": "...", "result": null },       
      { "success": false, "elementId": "...", "problemDetail": { ... } }
    ] 
  }  
 ```

### Rationale

Every other elementId-bearing endpoint in the API already accepts elementIds in the POST body. This change makes the update endpoints consistent with that pattern. 
The {elementId} path parameter endpoints were the last remaining outliers. The updates array shape mirrors the read-side bulk response — one item per element, success or failure reported individually — so the read/write calling convention is symmetric.  