### PR TITLE
Propose Solution for 296

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the i3X RFC, Implementation Guide, and demo are documente
 
 ## Summary
 
-- 2026-04-28 — `PUT /objects/{elementId}/value` and `PUT /objects/{elementId}/history` replaced by `POST /objects/value/update` and `POST /objects/history/update`, accepting elementIds in the request body as `{"updates": [{"elementId": "...", "value": {...}}, ...]}` and returning bulk responses. `GET /objects/{elementId}/history` removed — use `POST /objects/history` instead. (RFC §4.2.2, Implementation Guide, demo server)
+- 2026-04-28 — `PUT /objects/{elementId}/value` and `PUT /objects/{elementId}/history` replaced by `PUT /objects/value` and `PUT /objects/history`, accepting elementIds in the request body as `{"updates": [{"elementId": "...", "value": {...}}, ...]}` and returning bulk responses. `GET /objects/{elementId}/history` removed — use `POST /objects/history` instead. (RFC §4.2.2, Implementation Guide, demo server)
 - 2026-04-28 — `extendedAttributes` renamed to `schemaExtensions` in the object metadata response (RFC §3.1.1, Implementation Guide, and demo server)
 - 2026-04-23 — `/sync` returns HTTP 206 when subscription queue overflow causes updates to be dropped | [#258](https://github.com/cesmii/i3X/issues/258) [#288](https://github.com/cesmii/i3X/issues/288) 
 - 2026-04-23 — Error responses now use a `problemDetail` object (`title`, `status`, `detail`) in place of the previous `error` object (`code`, `message`). Applied to all endpoints and the demo server | [#294](https://github.com/cesmii/i3X/issues/294) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Changes accepted between 1.0 Beta and the 1.0 Release.
 All notable changes to the i3X RFC, Implementation Guide, and demo are documented here so that implementers can identify the exact deltas they need to adopt.
 
 ## Summary
-
+- 2026-04-29 — `responseDetail` replaces `problemDetail` as the response envelope field for error and partial-success details | [#294](https://github.com/cesmii/i3X/issues/294)
 - 2026-04-28 — `PUT /objects/{elementId}/value` and `PUT /objects/{elementId}/history` replaced by `PUT /objects/value` and `PUT /objects/history`, accepting elementIds in the request body as `{"updates": [{"elementId": "...", "value": {...}}, ...]}` and returning bulk responses. `GET /objects/{elementId}/history` removed — use `POST /objects/history` instead. (RFC §4.2.2, Implementation Guide, demo server)
 - 2026-04-28 — `extendedAttributes` renamed to `schemaExtensions` in the object metadata response (RFC §3.1.1, Implementation Guide, and demo server)
 - 2026-04-23 — `/sync` returns HTTP 206 when subscription queue overflow causes updates to be dropped | [#258](https://github.com/cesmii/i3X/issues/258) [#288](https://github.com/cesmii/i3X/issues/288) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,5 +6,6 @@ All notable changes to the i3X RFC, Implementation Guide, and demo are documente
 
 ## Summary
 
+- 2026-04-28 — `extendedAttributes` renamed to `schemaExtensions` in the object metadata response (RFC §3.1.1, Implementation Guide, and demo server)
 - 2026-04-23 — `/sync` returns HTTP 206 when subscription queue overflow causes updates to be dropped | [#258](https://github.com/cesmii/i3X/issues/258) [#288](https://github.com/cesmii/i3X/issues/288) 
 - 2026-04-23 — Error responses now use a `problemDetail` object (`title`, `status`, `detail`) in place of the previous `error` object (`code`, `message`). Applied to all endpoints and the demo server | [#294](https://github.com/cesmii/i3X/issues/294) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the i3X RFC, Implementation Guide, and demo are documente
 
 ## Summary
 
+- 2026-04-28 — `PUT /objects/{elementId}/value` and `PUT /objects/{elementId}/history` replaced by `POST /objects/value/update` and `POST /objects/history/update`, accepting elementIds in the request body as `{"updates": [{"elementId": "...", "value": {...}}, ...]}` and returning bulk responses. `GET /objects/{elementId}/history` removed — use `POST /objects/history` instead. (RFC §4.2.2, Implementation Guide, demo server)
 - 2026-04-28 — `extendedAttributes` renamed to `schemaExtensions` in the object metadata response (RFC §3.1.1, Implementation Guide, and demo server)
 - 2026-04-23 — `/sync` returns HTTP 206 when subscription queue overflow causes updates to be dropped | [#258](https://github.com/cesmii/i3X/issues/258) [#288](https://github.com/cesmii/i3X/issues/288) 
 - 2026-04-23 — Error responses now use a `problemDetail` object (`title`, `status`, `detail`) in place of the previous `error` object (`code`, `message`). Applied to all endpoints and the demo server | [#294](https://github.com/cesmii/i3X/issues/294) 

--- a/RFC for Contextualized Manufacturing Information API.md
+++ b/RFC for Contextualized Manufacturing Information API.md
@@ -309,7 +309,7 @@ If no elements have changed since the last Sync call, the response MUST be an em
 
 Each update in the queue carries a monotonically increasing `sequenceNumber`. The client MAY include a `lastSequenceNumber` in the Sync call to acknowledge all updates with a sequence number at or below that value; the implementation MUST remove those acknowledged updates before returning the remaining queue. If `lastSequenceNumber` is omitted the implementation MUST NOT clear the queue. The implementation must maintain state for all pending (un-acknowledged) updates, subject to server-imposed queue limits.
 
-When the server drops updates due to queue limits, it MUST signal data loss to the client by returning HTTP 206 (Partial Content) instead of HTTP 200. The response body MUST use `"success": true` with the standard `result` payload and an additional top-level `problemDetail` object. The `problemDetail` object MUST include the following fields:
+When the server drops updates due to queue limits, it MUST signal data loss to the client by returning HTTP 206 (Partial Content) instead of HTTP 200. The response body MUST use `"success": true` with the standard `result` payload and an additional top-level `responseDetail` object. The `responseDetail` object MUST include the following fields:
 - `title`: a short human-readable summary of the problem
 - `status`: the HTTP status code (206)
 - `detail`: a human-readable explanation of what was lost and why
@@ -342,17 +342,21 @@ All responses MUST be wrapped in a standard envelope. Successful single-item res
 ```
 Successful bulk responses (accepting an array of ElementIds) MUST use a `results` array with per-item success or failure indicated inline:
 ```json
-{ "success": false, "results": [ { "success": true, "elementId": "...", "result": <data> }, { "success": false, "elementId": "...", "problemDetail": { "title": "Not Found", "status": 404, "detail": "..." } } ] }
+{ "success": false, "results": [ { "success": true, "elementId": "...", "result": <data> }, { "success": false, "elementId": "...", "responseDetail": { "title": "Not Found", "status": 404, "detail": "..." } } ] }
 ```
-The top-level `success` is `false` if any item in a bulk response failed. Failure responses MUST use:
+The top-level `success` is `false` if any item in a bulk response failed. Failure responses MUST include a top-level `responseDetail` object:
 ```json
-{ "success": false, "problemDetail": { "title": "<summary>", "status": <HTTP status code>, "detail": "<description>" } }
+{ "success": false, "responseDetail": { "title": "<summary>", "status": <HTTP status code>, "detail": "<description>" } }
 ```
-Partial success responses (HTTP 206) MUST use `"success": true` with the standard `result` payload and an additional top-level `problemDetail` object:
+Partial success responses (HTTP 206) MUST use `"success": true` with the standard `result` payload and MUST include a top-level `responseDetail` object:
 ```json
-{ "success": true, "result": <data>, "problemDetail": { "title": "<summary>", "status": 206, "detail": "<description>" } }
+{ "success": true, "result": <data>, "responseDetail": { "title": "<summary>", "status": 206, "detail": "<description>" } }
 ```
-Error objects MUST follow [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) (Problem Details for HTTP APIs), and include the following fields:
+Success responses (HTTP 2xx) MAY include a top-level `responseDetail` object to convey additional context without indicating failure:
+```json
+{ "success": true, "result": <data>, "responseDetail": { "title": "<summary>", "status": 200, "detail": "<informational context>" } }
+```
+The `responseDetail` object MUST follow [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) (Problem Details for HTTP APIs), and include the following fields:
  - `title` is a short human-readable summary of the problem type
  - `status` is the HTTP status code
  - `detail` is a human-readable explanation specific to this occurrence

--- a/RFC for Contextualized Manufacturing Information API.md
+++ b/RFC for Contextualized Manufacturing Information API.md
@@ -81,7 +81,7 @@ When a client requests metadata, the server MUST return a `metadata` block along
 **Optional in the metadata block** — the server MAY include these where available:
 - description: a human-readable description conveying context or intent beyond what the DisplayName communicates
 - engUnit: the engineering unit for the element's value. Where present, definitions from [UNECE Recommendation Number 20](https://unece.org/trade/documents/2021/06/uncefact-rec20-0) MUST be used.
-- extendedAttributes: present only when `isExtended: true`. Contains non-conformant attributes and their inferred JSON Schema fragments, keyed by attribute name. Declared attributes are omitted — clients look those up from the ObjectType schema.
+- schemaExtensions: present only when `isExtended: true`. Contains non-conformant attributes and their inferred JSON Schema fragments, keyed by attribute name. Declared attributes are omitted — clients look those up from the ObjectType schema.
 - system: vendor-defined key/value pairs for platform-specific metadata not covered by standard fields. Values MUST be limited to strings, numbers, and booleans.
 
 ### 3.2 Object Relationships
@@ -182,7 +182,7 @@ If the ElementId exists as an instance object, this query MUST return the instan
 
 If an instance object differs from its Type definition, information about additional members is surfaced inline on all object responses via the `isExtended` and `extendedAttributes` fields defined in [section 3.1.1](#311-required-object-metadata).
 
-When `isExtended` is true and the client requests metadata, the response MUST include an `extendedAttributes` field containing the non-conformant attributes and their inferred JSON Schema fragments, keyed by attribute name. Declared (conformant) attributes are omitted from `extendedAttributes` — clients may look those up from the ObjectType schema identified by `typeElementId`.
+When `isExtended` is true and the client requests metadata, the response MUST include a `schemaExtensions` field containing the non-conformant attributes and their inferred JSON Schema fragments, keyed by attribute name. Declared (conformant) attributes are omitted from `schemaExtensions` — clients may look those up from the ObjectType schema identified by `typeElementId`.
 
 Implementations SHOULD resolve `allOf` inheritance chains in the declared type schema before determining conformance, so that inherited attributes are not incorrectly reported as extended.
 

--- a/RFC for Contextualized Manufacturing Information API.md
+++ b/RFC for Contextualized Manufacturing Information API.md
@@ -232,21 +232,19 @@ When invoked as a Query, the response MUST return a `values` array where each en
 
 Implementations MAY include the ability to write to the LastKnownValue. If this feature is implemented, the following considerations apply:
 
-When invoked as an Update, the LastKnownValue interface MUST accept a new current value for the requested object to be recorded, by ElementId. If the implementation supports write-back to a Control System (for example, via an interface to a PLC) additional security requirements outside the scope of this proposal MUST be considered.
+When invoked as an Update, the LastKnownValue interface MUST accept an array of `{elementId, value}` pairs in the request body. Each entry identifies the target Object by ElementId in the body (not in the URL path) and provides the new value in VQT format. If the implementation supports write-back to a Control System (for example, via an interface to a PLC) additional security requirements outside the scope of this proposal MUST be considered.
 
 Clients MUST write the complete value for the object. Partial attribute updates are not supported; the written value replaces the current value in its entirety.
 
-When invoked as an Update the LastKnownValue interface MAY accept an array of current values for an array of ElementIds.
+The response MUST use the bulk response envelope defined in [section 5.1.1](#511-response-serialization), with a per-item success or failure result for each ElementId in the request.
 
 ##### 4.2.2.2 Object Element HistoricalValue
 
 Implementations MAY include the ability to write to HistoricalValue(s). If this feature is implemented, the following considerations apply:
 
-When invoked as an Update, the HistoricalValue interface MUST accept an updated historical value for the requested object and timestamp, by ElementId.
+When invoked as an Update, the HistoricalValue interface MUST accept an array of `{elementId, value}` pairs in the request body. Each entry identifies the target Object by ElementId in the body (not in the URL path) and provides the value in VQT format. The `timestamp` field in the VQT identifies the historical record to create or replace.
 
-When invoked as an Update, the HistoricalValue interface MAY accept an array of updated historical values for an array of specified objects and timestamps, by ElementId.
-
-When invoked in order to Create a new historical record, the HistoricalValue interface MAY accept an array of new historical values for an array of specified objects and timestamps, by ElementId.
+The response MUST use the bulk response envelope defined in [section 5.1.1](#511-response-serialization), with a per-item success or failure result for each ElementId in the request.
 
 When updating Historical data, the implementation SHOULD implement auditing or tracking of such changes.
 

--- a/demo/server/app.py
+++ b/demo/server/app.py
@@ -165,7 +165,7 @@ app.add_middleware(
 async def http_exception_handler(request: Request, exc: HTTPException):
     return JSONResponse(
         status_code=exc.status_code,
-        content={"success": False, "problemDetail": {"title": _HTTP_TITLES.get(exc.status_code, "Error"), "status": exc.status_code, "detail": exc.detail}}
+        content={"success": False, "responseDetail": {"title": _HTTP_TITLES.get(exc.status_code, "Error"), "status": exc.status_code, "detail": exc.detail}}
     )
 
 

--- a/demo/server/data_sources/mock/mock_data.py
+++ b/demo/server/data_sources/mock/mock_data.py
@@ -499,7 +499,7 @@ I3X_DATA = {
             # Example of an extended object: typed as temperature-sensor-type (which declares only
             # 'temperature' and 'unit'), but its value also carries vendor_serial and firmware_version
             # — attributes not in the declared schema. isExtended=true will be set on this object,
-            # and extendedAttributes will be populated when includeMetadata=true is requested.
+            # and schemaExtensions will be populated when includeMetadata=true is requested.
             "elementId": "sensor-003",
             "displayName": "TempSensor-VendorX",
             "typeElementId": "temperature-sensor-type",

--- a/demo/server/models.py
+++ b/demo/server/models.py
@@ -275,7 +275,7 @@ class ObjectInstanceMetadata(BaseModel):
     sourceTypeId: Optional[str] = None
     description: Optional[str] = None
     relationships: Optional[Dict[str, Any]] = None
-    extendedAttributes: Optional[Dict[str, Any]] = None
+    schemaExtensions: Optional[Dict[str, Any]] = None
     system: Optional[Dict[str, Any]] = None
 
 

--- a/demo/server/models.py
+++ b/demo/server/models.py
@@ -108,6 +108,12 @@ class HistoricalValue(BaseModel):
     )
 
 
+class VQT(BaseModel):
+    value: Any
+    quality: str = Field(..., description="Data quality indicator: Good, GoodNoData, Bad, or Uncertain")
+    timestamp: str = Field(..., description="RFC 3339 UTC timestamp when this value was recorded")
+
+
 # RFC 4.2.2.1 - Object Element LastKnownValue update
 class ValueUpdateItem(BaseModel):
     elementId: str = Field(..., description="The elementId of the Object to update")
@@ -285,12 +291,6 @@ class ObjectInstanceResponse(BaseModel):
 class RelatedObjectResult(BaseModel):
     sourceRelationship: str
     object: ObjectInstanceResponse
-
-
-class VQT(BaseModel):
-    value: Any
-    quality: str = Field(..., description="Data quality indicator: Good, GoodNoData, Bad, or Uncertain")
-    timestamp: str = Field(..., description="RFC 3339 UTC timestamp when this value was recorded")
 
 
 class CurrentValueResult(BaseModel):

--- a/demo/server/models.py
+++ b/demo/server/models.py
@@ -241,7 +241,7 @@ class ErrorDetail(BaseModel):
 
 class ErrorResponse(BaseModel):
     success: bool = False
-    problemDetail: ErrorDetail
+    responseDetail: ErrorDetail
 
 
 class SuccessResponse(BaseModel, Generic[T]):
@@ -254,7 +254,7 @@ class BulkResultItem(BaseModel, Generic[T]):
     elementId: Optional[str] = None
     subscriptionId: Optional[str] = None
     result: Optional[T] = None
-    problemDetail: Optional[ErrorDetail] = None
+    responseDetail: Optional[ErrorDetail] = None
 
 
 class BulkResponse(BaseModel, Generic[T]):

--- a/demo/server/models.py
+++ b/demo/server/models.py
@@ -108,31 +108,24 @@ class HistoricalValue(BaseModel):
     )
 
 
-# RFC 4.2.2.1 - Object Element LastKnownValue
-class UpdateRequest(BaseModel):
-    elementIds: List[str]
-    values: List[Any]
+# RFC 4.2.2.1 - Object Element LastKnownValue update
+class ValueUpdateItem(BaseModel):
+    elementId: str = Field(..., description="The elementId of the Object to update")
+    value: Any = Field(..., description="The VQT value to write. Must conform to the Object's type schema.")
 
 
-# TODO: the RFC doesn't say what this should be
-class UpdateResult(BaseModel):
-    elementId: str
-    success: bool
-    message: str
+class UpdateValueRequest(BaseModel):
+    updates: List[ValueUpdateItem] = Field(..., description="Array of elementId/value pairs to write")
 
 
-# 4.2.2.2 Object Element HistoricalValue
-class HistoricalValueUpdate(BaseModel):
-    elementId: str
-    timestamp: str  # ISO8601 string
-    value: Any
+# RFC 4.2.2.2 - Object Element HistoricalValue update
+class HistoryUpdateItem(BaseModel):
+    elementId: str = Field(..., description="The elementId of the Object to update")
+    value: VQT = Field(..., description="The VQT value to write, including timestamp")
 
 
-class HistoricalUpdateResult(BaseModel):
-    elementId: str
-    timestamp: str
-    success: bool
-    message: str
+class UpdateHistoryRequest(BaseModel):
+    updates: List[HistoryUpdateItem] = Field(..., description="Array of elementId/value pairs to write")
 
 
 class CreateSubscriptionRequest(BaseModel):

--- a/demo/server/models.py
+++ b/demo/server/models.py
@@ -114,10 +114,17 @@ class VQT(BaseModel):
     timestamp: str = Field(..., description="RFC 3339 UTC timestamp when this value was recorded")
 
 
+class VQTInput(BaseModel):
+    """VQT for write requests — quality and timestamp are optional (server supplies defaults)."""
+    value: Any
+    quality: Optional[str] = Field(default="Good", description="Data quality indicator. Defaults to 'Good' if omitted.")
+    timestamp: Optional[str] = Field(default=None, description="RFC 3339 timestamp. Defaults to server time if omitted.")
+
+
 # RFC 4.2.2.1 - Object Element LastKnownValue update
 class ValueUpdateItem(BaseModel):
     elementId: str = Field(..., description="The elementId of the Object to update")
-    value: Any = Field(..., description="The VQT value to write. Must conform to the Object's type schema.")
+    value: VQTInput = Field(..., description="The VQT value to write. Must conform to the Object's type schema.")
 
 
 class UpdateValueRequest(BaseModel):

--- a/demo/server/routers/objects.py
+++ b/demo/server/routers/objects.py
@@ -17,7 +17,7 @@ from models import (
     CurrentValueResult,
     HistoricalValueResult,
 )
-from .utils import getObject, success_response, error_response, bulk_response, transform_value_result, get_data_source, BASE_ERROR_RESPONSES, NOT_FOUND_RESPONSE, PARTIAL_CONTENT_DESCRIPTION
+from .utils import getObject, success_response, bulk_response, transform_value_result, get_data_source, BASE_ERROR_RESPONSES, PARTIAL_CONTENT_DESCRIPTION
 
 explore = APIRouter(prefix="", tags=["Explore"])
 query = APIRouter(prefix="", tags=["Query"])
@@ -203,8 +203,8 @@ def query_historical_values(
 
 
 # RFC 4.2.2.1 - Object Element LastKnownValue update
-@update.post(
-    "/objects/value/update",
+@update.put(
+    "/objects/value",
     summary="Update Values of Objects",
     operation_id="updateObjectValues",
     response_model=BulkResponse[None],
@@ -229,9 +229,7 @@ def update_object_values(
             results.append({"success": False, "elementId": eid, "problemDetail": {"title": "Not Found", "status": 404, "detail": f"Element not found: {eid}"}})
             continue
         try:
-            body = item.value
-            value = body["value"] if isinstance(body, dict) and "value" in body else body
-            data_source.update_instance_value(eid, value)
+            data_source.update_instance_value(eid, item.value.value)
             results.append({"success": True, "elementId": eid, "result": None})
         except Exception as e:
             results.append({"success": False, "elementId": eid, "problemDetail": {"title": "Error", "status": 500, "detail": str(e)}})
@@ -239,8 +237,8 @@ def update_object_values(
 
 
 # RFC 4.2.2.2 - Object Element HistoricalValue update
-@update.post(
-    "/objects/history/update",
+@update.put(
+    "/objects/history",
     summary="Update Historical Values of Objects",
     operation_id="updateObjectHistory",
     responses={501: {"model": ErrorResponse, "description": "Not Implemented — optional feature not supported by this server"}, **BASE_ERROR_RESPONSES},

--- a/demo/server/routers/objects.py
+++ b/demo/server/routers/objects.py
@@ -1,12 +1,14 @@
-from fastapi import APIRouter, Path, Query, HTTPException, Body, Depends
+from fastapi import APIRouter, Query, HTTPException, Depends
 from fastapi.responses import JSONResponse
-from typing import Optional, Any, List
+from typing import Optional, List
 from urllib.parse import unquote
 from models import (
     GetObjectsRequest,
     GetRelatedObjectsRequest,
     GetObjectValueRequest,
     GetObjectHistoryRequest,
+    UpdateValueRequest,
+    UpdateHistoryRequest,
     SuccessResponse,
     BulkResponse,
     ErrorResponse,
@@ -200,84 +202,56 @@ def query_historical_values(
     return response_body
 
 
-# RFC 4.2.1.2 - Historical values for a single Object (convenience GET form)
-@query.get(
-    "/objects/{elementId}/history",
-    summary="Get Historical Values",
-    operation_id="getHistoricalValues",
-    response_model=SuccessResponse[HistoricalValueResult],
-    responses={206: {"model": SuccessResponse[HistoricalValueResult], "description": PARTIAL_CONTENT_DESCRIPTION}, **NOT_FOUND_RESPONSE, **BASE_ERROR_RESPONSES},
-)
-def get_historical_values(
-    elementId: str = Path(...),
-    startTime: Optional[str] = Query(default=None, description="ISO 8601 start time"),
-    endTime: Optional[str] = Query(default=None, description="ISO 8601 end time"),
-    maxDepth: int = Query(default=1, ge=0, description="Recursion depth through HasComponent. 0=infinite, 1=no recursion"),
-    data_source=Depends(get_data_source),
-):
-    """Return historical values for a single Object. Optionally filter by time range."""
-    elementId = unquote(elementId)
-    instance = data_source.get_instance_by_id(elementId)
-    if not instance:
-        raise HTTPException(status_code=404, detail=f"Element not found: {elementId}")
-
-    historical_values = data_source.get_instance_values_by_id(
-        elementId,
-        startTime,
-        endTime,
-        maxDepth,
-        returnHistory=True,
-    )
-    if not historical_values:
-        raise HTTPException(status_code=404, detail="No historical data available")
-
-    transformed, was_truncated = transform_value_result(elementId, historical_values, instance, is_history=True)
-    if transformed is None:
-        raise HTTPException(status_code=404, detail="No historical data available")
-
-    if was_truncated:
-        return JSONResponse(content={"success": True, "result": transformed}, status_code=206)
-    return {"success": True, "result": transformed}
-
-
 # RFC 4.2.2.1 - Object Element LastKnownValue update
-@update.put(
-    "/objects/{elementId}/value",
-    summary="Update Value of Object",
-    operation_id="updateObjectValue",
-    response_model=SuccessResponse[None],
-    responses={**NOT_FOUND_RESPONSE, **BASE_ERROR_RESPONSES},
+@update.post(
+    "/objects/value/update",
+    summary="Update Values of Objects",
+    operation_id="updateObjectValues",
+    response_model=BulkResponse[None],
+    responses={**BASE_ERROR_RESPONSES},
 )
-def update_object(
-    elementId: str = Path(...),
-    body: Any = Body(...),
+def update_object_values(
+    request_body: UpdateValueRequest,
     data_source=Depends(get_data_source),
 ):
-    """Update the value of an Object"""
-    if not data_source.get_instance_by_id(elementId):
-        raise HTTPException(status_code=404, detail=f"Element not found: {elementId}")
-    try:
-        # Unwrap VQT body: {value, quality, timestamp} -> extract inner value
-        if isinstance(body, dict) and "value" in body:
-            value = body["value"]
-        else:
-            value = body
-        data_source.update_instance_value(elementId, value)
-        return success_response(None)
-    except Exception as e:
-        return error_response(str(e))
+    """
+    Update the current value of one or more Objects.
+
+    Request body: {"updates": [{"elementId": "...", "value": {...}}, ...]}
+
+    Returns bulk response with succeeded/failed per elementId.
+    """
+    results = []
+    for item in request_body.updates:
+        eid = unquote(item.elementId)
+        instance = data_source.get_instance_by_id(eid)
+        if not instance:
+            results.append({"success": False, "elementId": eid, "problemDetail": {"title": "Not Found", "status": 404, "detail": f"Element not found: {eid}"}})
+            continue
+        try:
+            body = item.value
+            value = body["value"] if isinstance(body, dict) and "value" in body else body
+            data_source.update_instance_value(eid, value)
+            results.append({"success": True, "elementId": eid, "result": None})
+        except Exception as e:
+            results.append({"success": False, "elementId": eid, "problemDetail": {"title": "Error", "status": 500, "detail": str(e)}})
+    return bulk_response(results)
 
 
-# RFC 4.2.2.2 - Object Element HistoricalValue
-@update.put(
-    "/objects/{elementId}/history",
-    summary="Update Historical Values of Object",
+# RFC 4.2.2.2 - Object Element HistoricalValue update
+@update.post(
+    "/objects/history/update",
+    summary="Update Historical Values of Objects",
     operation_id="updateObjectHistory",
-    responses={501: {"model": ErrorResponse, "description": "Not Implemented — optional feature not supported by this server"}, **NOT_FOUND_RESPONSE, **BASE_ERROR_RESPONSES},
+    responses={501: {"model": ErrorResponse, "description": "Not Implemented — optional feature not supported by this server"}, **BASE_ERROR_RESPONSES},
 )
 def update_object_history(
-    elementId: str = Path(...),
+    request_body: UpdateHistoryRequest,
     data_source=Depends(get_data_source),
 ):
-    """Update the historical values for one or more Objects"""
+    """
+    Update historical values for one or more Objects.
+
+    Request body: {"updates": [{"elementId": "...", "value": {"value": ..., "quality": "...", "timestamp": "..."}}, ...]}
+    """
     raise HTTPException(status_code=501, detail="Operation not implemented")

--- a/demo/server/routers/objects.py
+++ b/demo/server/routers/objects.py
@@ -65,7 +65,7 @@ def query_objects_by_id(
             extra_attrs = data_source.get_instance_extra_attributes(eid_decoded)
             results.append({"success": True, "elementId": eid_decoded, "result": getObject(instance, request_body.includeMetadata, type_info, extra_attrs)})
         else:
-            results.append({"success": False, "elementId": eid_decoded, "problemDetail": {"title": "Not Found", "status": 404, "detail": f"Element not found: {eid_decoded}"}})
+            results.append({"success": False, "elementId": eid_decoded, "responseDetail": {"title": "Not Found", "status": 404, "detail": f"Element not found: {eid_decoded}"}})
 
     return bulk_response(results)
 
@@ -105,7 +105,7 @@ def query_related_objects(
                 })
             results.append({"success": True, "elementId": eid_decoded, "result": related_result})
         else:
-            results.append({"success": False, "elementId": eid_decoded, "problemDetail": {"title": "Not Found", "status": 404, "detail": f"Element not found: {eid_decoded}"}})
+            results.append({"success": False, "elementId": eid_decoded, "responseDetail": {"title": "Not Found", "status": 404, "detail": f"Element not found: {eid_decoded}"}})
 
     return bulk_response(results)
 
@@ -145,9 +145,9 @@ def query_last_known_values(
                     any_truncated = True
                 results.append({"success": True, "elementId": eid_decoded, "result": transformed})
             else:
-                results.append({"success": False, "elementId": eid_decoded, "problemDetail": {"title": "Not Found", "status": 404, "detail": "No value available"}})
+                results.append({"success": False, "elementId": eid_decoded, "responseDetail": {"title": "Not Found", "status": 404, "detail": "No value available"}})
         else:
-            results.append({"success": False, "elementId": eid_decoded, "problemDetail": {"title": "Not Found", "status": 404, "detail": f"Element not found: {eid_decoded}"}})
+            results.append({"success": False, "elementId": eid_decoded, "responseDetail": {"title": "Not Found", "status": 404, "detail": f"Element not found: {eid_decoded}"}})
 
     response_body = bulk_response(results)
     if any_truncated:
@@ -192,9 +192,9 @@ def query_historical_values(
                     any_truncated = True
                 results.append({"success": True, "elementId": eid_decoded, "result": transformed})
             else:
-                results.append({"success": False, "elementId": eid_decoded, "problemDetail": {"title": "Not Found", "status": 404, "detail": "No historical data available"}})
+                results.append({"success": False, "elementId": eid_decoded, "responseDetail": {"title": "Not Found", "status": 404, "detail": "No historical data available"}})
         else:
-            results.append({"success": False, "elementId": eid_decoded, "problemDetail": {"title": "Not Found", "status": 404, "detail": f"Element not found: {eid_decoded}"}})
+            results.append({"success": False, "elementId": eid_decoded, "responseDetail": {"title": "Not Found", "status": 404, "detail": f"Element not found: {eid_decoded}"}})
 
     response_body = bulk_response(results)
     if any_truncated:
@@ -226,13 +226,13 @@ def update_object_values(
         eid = unquote(item.elementId)
         instance = data_source.get_instance_by_id(eid)
         if not instance:
-            results.append({"success": False, "elementId": eid, "problemDetail": {"title": "Not Found", "status": 404, "detail": f"Element not found: {eid}"}})
+            results.append({"success": False, "elementId": eid, "responseDetail": {"title": "Not Found", "status": 404, "detail": f"Element not found: {eid}"}})
             continue
         try:
             data_source.update_instance_value(eid, item.value.value)
             results.append({"success": True, "elementId": eid, "result": None})
         except Exception as e:
-            results.append({"success": False, "elementId": eid, "problemDetail": {"title": "Error", "status": 500, "detail": str(e)}})
+            results.append({"success": False, "elementId": eid, "responseDetail": {"title": "Error", "status": 500, "detail": str(e)}})
     return bulk_response(results)
 
 

--- a/demo/server/routers/subscriptions.py
+++ b/demo/server/routers/subscriptions.py
@@ -111,7 +111,7 @@ def register_objects(request: Request, req: RegisterMonitoredItemsRequest):
 
     for eid in req.elementIds:
         if not data_source.get_instance_by_id(eid):
-            results.append({"success": False, "elementId": eid, "problemDetail": {"title": "Not Found", "status": 404, "detail": f"Element not found: {eid}"}})
+            results.append({"success": False, "elementId": eid, "responseDetail": {"title": "Not Found", "status": 404, "detail": f"Element not found: {eid}"}})
             continue
         tree = collect_instance_tree(eid, req.maxDepth, 0, data_source.get_all_instances())
         for item in tree:
@@ -142,7 +142,7 @@ def unregister_objects(request: Request, req: RegisterMonitoredItemsRequest):
 
     for eid in req.elementIds:
         if not data_source.get_instance_by_id(eid):
-            results.append({"success": False, "elementId": eid, "problemDetail": {"title": "Not Found", "status": 404, "detail": f"Element not found: {eid}"}})
+            results.append({"success": False, "elementId": eid, "responseDetail": {"title": "Not Found", "status": 404, "detail": f"Element not found: {eid}"}})
             continue
         tree = collect_instance_tree(eid, req.maxDepth, 0, data_source.get_all_instances())
         for item in tree:
@@ -250,7 +250,7 @@ def sync_subscription(request: Request, req: SyncRequest):
         body = {
             "success": True,
             "result": updates,
-            "problemDetail": {
+            "responseDetail": {
                 "title": "Updates dropped due to queue overflow",
                 "status": 206,
                 "detail": (
@@ -292,7 +292,7 @@ def delete_subscriptions(request: Request, req: DeleteSubscriptionsRequest):
             request.app.state.I3X_DATA_SUBSCRIPTIONS.pop(index)
             results.append({"success": True, "subscriptionId": sub_id, "result": None})
         else:
-            results.append({"success": False, "subscriptionId": sub_id, "problemDetail": {"title": "Not Found", "status": 404, "detail": f"Subscription not found: {sub_id}"}})
+            results.append({"success": False, "subscriptionId": sub_id, "responseDetail": {"title": "Not Found", "status": 404, "detail": f"Subscription not found: {sub_id}"}})
 
     return bulk_response(results)
 
@@ -322,7 +322,7 @@ def list_subscriptions(request: Request, req: ListSubscriptionsRequest):
                 },
             })
         else:
-            results.append({"success": False, "subscriptionId": sub_id, "problemDetail": {"title": "Not Found", "status": 404, "detail": f"Subscription not found: {sub_id}"}})
+            results.append({"success": False, "subscriptionId": sub_id, "responseDetail": {"title": "Not Found", "status": 404, "detail": f"Subscription not found: {sub_id}"}})
 
     return bulk_response(results)
 

--- a/demo/server/routers/typeDefinitions.py
+++ b/demo/server/routers/typeDefinitions.py
@@ -52,7 +52,7 @@ def query_object_types_by_id(
         if obj_type:
             results.append({"success": True, "elementId": eid_decoded, "result": formatObjectType(obj_type)})
         else:
-            results.append({"success": False, "elementId": eid_decoded, "problemDetail": {"title": "Not Found", "status": 404, "detail": f"Object type not found: {eid_decoded}"}})
+            results.append({"success": False, "elementId": eid_decoded, "responseDetail": {"title": "Not Found", "status": 404, "detail": f"Object type not found: {eid_decoded}"}})
 
     return bulk_response(results)
 
@@ -95,6 +95,6 @@ def query_relationship_types_by_id(
         if rel_type:
             results.append({"success": True, "elementId": eid_decoded, "result": rel_type})
         else:
-            results.append({"success": False, "elementId": eid_decoded, "problemDetail": {"title": "Not Found", "status": 404, "detail": f"Relationship type not found: {eid_decoded}"}})
+            results.append({"success": False, "elementId": eid_decoded, "responseDetail": {"title": "Not Found", "status": 404, "detail": f"Relationship type not found: {eid_decoded}"}})
 
     return bulk_response(results)

--- a/demo/server/routers/utils.py
+++ b/demo/server/routers/utils.py
@@ -76,7 +76,7 @@ def getObject(instance: Any, includeMetadata: bool, type_info: Any = None, extra
     metadata["relationships"] = instance.get("relationships", {})
 
     if extra_attrs:
-        metadata["extendedAttributes"] = extra_attrs
+        metadata["schemaExtensions"] = extra_attrs
 
     # Collect vendor/server-defined instance-level properties (RFC 3.1.2 optional metadata)
     # into metadata.system. Values are limited to primitives (string, number, boolean).

--- a/demo/server/routers/utils.py
+++ b/demo/server/routers/utils.py
@@ -5,7 +5,7 @@ from models import ErrorResponse
 
 # Shared response schema dicts for use in route decorators
 BASE_ERROR_RESPONSES = {
-    "default": {"model": ErrorResponse, "description": "Error — see problemDetail.code for the HTTP status code (400, 401, 403, 404, 500, etc.)"},
+    "default": {"model": ErrorResponse, "description": "Error — see responseDetail.code for the HTTP status code (400, 401, 403, 404, 500, etc.)"},
 }
 
 NOT_FOUND_RESPONSE = {
@@ -39,7 +39,7 @@ _HTTP_TITLES = {
 
 def error_response(detail, status=500):
     title = _HTTP_TITLES.get(status, "Error")
-    return {"success": False, "problemDetail": {"title": title, "status": status, "detail": detail}}
+    return {"success": False, "responseDetail": {"title": title, "status": status, "detail": detail}}
 
 
 def bulk_response(results):

--- a/demo/server/test_app.py
+++ b/demo/server/test_app.py
@@ -1,6 +1,7 @@
 import unittest
 import json
 from fastapi.testclient import TestClient
+import httpx
 from app import app
 from models import Namespace, ObjectType, ObjectInstanceMinimal
 import threading
@@ -255,19 +256,23 @@ class TestI3XEndpoints(unittest.TestCase):
         results = []
 
         def stream_reader():
-            with self.client.stream("POST", "/subscriptions/stream", json={"subscriptionId": subscription_id}) as stream_resp:
-                self.assertEqual(stream_resp.status_code, 200)
-                count = 0
-                for line in stream_resp.iter_lines():
-                    if line:
-                        decoded = line.decode("utf-8")
-                        print("Received chunk:", decoded)
-                        results.append(decoded)
-                        count += 1
-                        if count >= 3:  # read 3 update batches then stop
-                            break
+            try:
+                timeout = httpx.Timeout(5.0, read=8.0)
+                with self.client.stream("POST", "/subscriptions/stream", json={"subscriptionId": subscription_id}, timeout=timeout) as stream_resp:
+                    self.assertEqual(stream_resp.status_code, 200)
+                    count = 0
+                    for line in stream_resp.iter_lines():
+                        if line:
+                            decoded = line.decode("utf-8")
+                            print("Received chunk:", decoded)
+                            results.append(decoded)
+                            count += 1
+                            if count >= 3:  # read 3 update batches then stop
+                                break
+            except httpx.TimeoutException:
+                pass  # stream timed out cleanly
 
-        thread = threading.Thread(target=stream_reader)
+        thread = threading.Thread(target=stream_reader, daemon=True)
         thread.start()
         thread.join(timeout=10)
 

--- a/spec/IMPLEMENTATION_GUIDE.md
+++ b/spec/IMPLEMENTATION_GUIDE.md
@@ -118,10 +118,26 @@ Successful responses return an HTTP 200 with the following shape. Note the `resu
 }
 ```
 
+Success responses (HTTP 2xx, including partial success) MAY include `responseDetail` ([RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) - Problem Details for HTTP APIs) to convey informational context: 
+```json
+{
+  "success": true,
+  "result": <data>,
+  "responseDetail": {
+    "title": <title>,
+    "status": 2xx,
+    "detail": <detail>
+  }
+}
+```
+
 | Field                           | Type    | Required | Description                                                 |
 |---------------------------------|---------|----------|-------------------------------------------------------------|
 | `success`                       | boolean | Yes      | True if the request is successful. HTTP return must be 200. |
-| `result`                        | any     | Yes      | Endpoint specific result.                                   |
+| `result`                        | any     | Yes      | Endpoint specific result. 
+| `responseDetail.title`    | string  | No      | Short, human-readable summary of the problem type (e.g. `"Not Found"`). |
+| `responseDetail.status`   | number  | No      | The HTTP status code.                                                   |
+| `responseDetail.detail`   | string  | No      | Human-readable explanation specific to this occurrence.                 |
 
 Examples:
 
@@ -134,36 +150,44 @@ Examples:
 
 // PUT /objects/value (write succeeded)
 { "success": true, "results": [{ "success": true, "elementId": "pump-101", "result": null }] }
+
+// POST /subscriptions/sync (overflow occurred, POST returns HTTP 206 Partial Content)
+{
+  "success": true, "result": [...], "responseDetail": { "title": "Partial results returned", "status": 206, "detail": "Result set was truncated due to server-imposed depth limits." }
+}
 ```
 
 ### Failure
 
-Failures return an HTTP error code with the following shape. The `problemDetail` object follows [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) (Problem Details for HTTP APIs).
+Failures return an HTTP error code with the following shape. The `responseDetail` object follows [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) (Problem Details for HTTP APIs) and communicates additional context about a response. It MUST be present on failure responses.
 
 ```json
 {
   "success": false,
-  "problemDetail": {
+  "responseDetail": {
     "title": "Not Found",
     "status": 404,
     "detail": "Element not found: pump-101"
   }
 }
-```
-
 | Field                    | Type    | Required | Description                                                             |
 |--------------------------|---------|----------|-------------------------------------------------------------------------|
 | `success`                | boolean | Yes      | `false` for any error response.                                         |
-| `problemDetail.title`    | string  | Yes      | Short, human-readable summary of the problem type (e.g. `"Not Found"`). |
-| `problemDetail.status`   | number  | Yes      | The HTTP status code.                                                   |
-| `problemDetail.detail`   | string  | Yes      | Human-readable explanation specific to this occurrence.                 |
+
+| `responseDetail.title`    | string  | Yes      | Short, human-readable summary of the problem type (e.g. `"Not Found"`). |
+| `responseDetail.status`   | number  | Yes      | The HTTP status code.                                                   |
+| `responseDetail.detail`   | string  | Yes      | Human-readable explanation specific to this occurrence.                 |
+
+Failures (`success: false`) MUST include `responseDetail`:
+
+```
 
 The following HTTP status codes are used.
 
 | Code | Meaning | When to Use |
 |------|---------|-------------|
 | 200 | OK | Successful request |
-| 206 | Partial Content | Server fulfilled part of the request due to server-imposed limits. The response body includes a top-level `problemDetail` object. |
+| 206 | Partial Content | Server fulfilled part of the request due to server-imposed limits. The response body includes a top-level `responseDetail` object. |
 | 400 | Bad Request | Invalid parameters, malformed request body, or request the server cannot fulfill at all |
 | 401 | Unauthorized | Missing or invalid authentication |
 | 403 | Forbidden | Authenticated but not authorized |
@@ -175,7 +199,7 @@ Examples:
 
 ```json
 // GET /namespaces
-{ "success": false, "problemDetail": { "title": "Unauthorized", "status": 401, "detail": "User does not have access" }}
+{ "success": false, "responseDetail": { "title": "Unauthorized", "status": 401, "detail": "User does not have access" }}
 ```
 
 ### Bulk Response
@@ -196,7 +220,7 @@ The Server's response MUST be in the same order and the same size as the request
     {
       "success": false,
       "elementId": "non-existent",
-      "problemDetail": {
+      "responseDetail": {
         "title": "Not Found",
         "status": 404,
         "detail": "Element not found: non-existent"
@@ -621,7 +645,7 @@ Returns one or more Object Types given a collection of elementIds.
     {
       "success": false,
       "elementId": "string",
-      "problemDetail": {
+      "responseDetail": {
         "title": "Not Found",
         "status": 404,
         "detail": "Object type not found: string"
@@ -710,7 +734,7 @@ Returns one or more Relationship Types given a collection of elementIds.
     {
       "success": false,
       "elementId": "string",
-      "problemDetail": {
+      "responseDetail": {
         "title": "Not Found",
         "status": 404,
         "detail": "Relationship type not found: string"
@@ -838,7 +862,7 @@ Returns one or more Objects without data/values given a collection of elementIds
     {
       "success": false,
       "elementId": "string",
-      "problemDetail": {
+      "responseDetail": {
         "title": "Not Found",
         "status": 404,
         "detail": "Element not found: string"
@@ -878,7 +902,7 @@ Returns one or more Objects without data/values given a collection of elementIds
     {
       "success": false,
       "elementId": "string",
-      "problemDetail": {
+      "responseDetail": {
         "title": "Not Found",
         "status": 404,
         "detail": "Element not found: string"
@@ -943,7 +967,7 @@ Returns a bulk response with the related Objects for each queried elementId.
     {
       "success": false,
       "elementId": "string",
-      "problemDetail": {
+      "responseDetail": {
         "title": "Not Found",
         "status": 404,
         "detail": "Element not found: string"
@@ -1099,7 +1123,7 @@ Returns the last known value for one or more Objects.
     {
       "success": false,
       "elementId": "string",
-      "problemDetail": {
+      "responseDetail": {
         "title": "Not Found",
         "status": 404,
         "detail": "Element not found: string"
@@ -1184,7 +1208,7 @@ Returns the historical values for one or more Objects between a start and end ti
     {
       "success": false,
       "elementId": "string",
-      "problemDetail": {
+      "responseDetail": {
         "title": "Not Found",
         "status": 404,
         "detail": "Element not found: string"
@@ -1250,7 +1274,7 @@ Returns a bulk response with a result per elementId.
   "success": true,
   "results": [
     { "success": true, "elementId": "pump-101", "result": null },
-    { "success": false, "elementId": "bad-id", "problemDetail": { "title": "Not Found", "status": 404, "detail": "Element not found: bad-id" } }
+    { "success": false, "elementId": "bad-id", "responseDetail": { "title": "Not Found", "status": 404, "detail": "Element not found: bad-id" } }
   ]
 }
 ```
@@ -1611,7 +1635,7 @@ This approach ensures updates are not lost if the client crashes between receivi
 
 Servers maintain a queue for each subscription. When the queue is full and a new update arrives, the server MUST drop the oldest pending update to make room. If a client polls infrequently relative to the rate of change, it may miss updates.
 
-When the server has dropped updates since the client's last acknowledged sequence number, it MUST return **HTTP 206 (Partial Content)**. The response body has the same shape as a normal 200, with one addition: a `problemDetail` object:
+When the server has dropped updates since the client's last acknowledged sequence number, it MUST return **HTTP 206 (Partial Content)**. The response body has the same shape as a normal 200, with one addition: a `responseDetail` object:
 
 ```json
 HTTP 206
@@ -1620,7 +1644,7 @@ HTTP 206
   "result": [
     {"sequenceNumber": 151, "elementId": "sensor-001", "value": 72.5, "quality": "Good", "timestamp": "2025-01-08T10:30:01Z"}
   ],
-  "problemDetail": {
+  "responseDetail": {
     "title": "Updates dropped due to queue overflow",
     "status": 206,
     "detail": "Updates were dropped from the subscription queue because the server-imposed queue limit was reached. The client may assume that all sequence numbers between its last acknowledged sequence number and the first returned sequence number were dropped."
@@ -1700,7 +1724,7 @@ All subsequent calls (ack previous batch, fetch new):
   "result": [
     {"sequenceNumber": 151, "elementId": "sensor-001", "value": 74.1, "quality": "Good", "timestamp": "2025-01-08T10:35:00Z"}
   ],
-  "problemDetail": {
+  "responseDetail": {
     "title": "Updates dropped due to queue overflow",
     "status": 206,
     "detail": "Updates were dropped from the subscription queue because the server-imposed queue limit was reached. The client may assume that all sequence numbers between its last acknowledged sequence number and the first returned sequence number were dropped."

--- a/spec/IMPLEMENTATION_GUIDE.md
+++ b/spec/IMPLEMENTATION_GUIDE.md
@@ -132,7 +132,7 @@ Examples:
 // POST /subscriptions
 { "success": true, "result": { "subscriptionId": "Xf9q8wL1...", "displayName": "mySubscription" } }
 
-// POST /objects/value/update (write succeeded)
+// PUT /objects/value (write succeeded)
 { "success": true, "results": [{ "success": true, "elementId": "pump-101", "result": null }] }
 ```
 
@@ -510,8 +510,8 @@ Returns the server version and capabilities. Clients SHOULD call this endpoint b
 | `serverName`                    | string | No | Human-readable name for this server or deployment                  |
 | `capabilities`                       | object | Yes | Declares which optional features this server supports              |
 | `capabilities.query.history`         | boolean | Yes | True if `POST /objects/history` is supported                       |
-| `capabilities.update.current`        | boolean | Yes | True if `POST /objects/value/update` is supported              |
-| `capabilities.update.history`        | boolean | Yes | True if `POST /objects/history/update` is supported            |
+| `capabilities.update.current`        | boolean | Yes | True if `PUT /objects/value` is supported              |
+| `capabilities.update.history`        | boolean | Yes | True if `PUT /objects/history` is supported            |
 | `capabilities.subscribe.stream`      | boolean | Yes | True if `POST /subscriptions/stream` is supported                  |
 
 
@@ -1209,7 +1209,7 @@ It is the responsibility of the implementing platform to validate the input, inc
 
 ---
 
-#### `POST` /objects/value/update
+#### `PUT` /objects/value
 
 Update the current value of one or more Objects.
 
@@ -1257,7 +1257,7 @@ Returns a bulk response with a result per elementId.
 
 ---
 
-#### `POST` /objects/history/update
+#### `PUT` /objects/history
 
 Update historical values of one or more Objects.
 

--- a/spec/IMPLEMENTATION_GUIDE.md
+++ b/spec/IMPLEMENTATION_GUIDE.md
@@ -132,8 +132,8 @@ Examples:
 // POST /subscriptions
 { "success": true, "result": { "subscriptionId": "Xf9q8wL1...", "displayName": "mySubscription" } }
 
-// PUT /objects/{elementId}/value (write succeeded)
-{ "success": true, "result": null }
+// POST /objects/value/update (write succeeded)
+{ "success": true, "results": [{ "success": true, "elementId": "pump-101", "result": null }] }
 ```
 
 ### Failure
@@ -510,8 +510,8 @@ Returns the server version and capabilities. Clients SHOULD call this endpoint b
 | `serverName`                    | string | No | Human-readable name for this server or deployment                  |
 | `capabilities`                       | object | Yes | Declares which optional features this server supports              |
 | `capabilities.query.history`         | boolean | Yes | True if `POST /objects/history` is supported                       |
-| `capabilities.update.current`        | boolean | Yes | True if `PUT /objects/{elementId}/value` is supported              |
-| `capabilities.update.history`        | boolean | Yes | True if `PUT /objects/{elementId}/history` is supported            |
+| `capabilities.update.current`        | boolean | Yes | True if `POST /objects/value/update` is supported              |
+| `capabilities.update.history`        | boolean | Yes | True if `POST /objects/history/update` is supported            |
 | `capabilities.subscribe.stream`      | boolean | Yes | True if `POST /subscriptions/stream` is supported                  |
 
 
@@ -1209,15 +1209,9 @@ It is the responsibility of the implementing platform to validate the input, inc
 
 ---
 
-#### `PUT` /objects/{elementId}/value
+#### `POST` /objects/value/update
 
-Update the value of an Object.
-
-**Path Parameters:**
-
-| Name | Type | Required | Description |
-|------|------|----------|-------------|
-| `elementId` | string | Yes | The elementId of the Object to update |
+Update the current value of one or more Objects.
 
 **Request Body:**
 
@@ -1225,49 +1219,87 @@ The value to write in VQT format. The value will replace the current Object valu
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `value` | any | Yes | The data value to write. Must conform to the Object's type schema. `null` is permitted for nullable fields — see [Null Value Handling](#null-value-handling). |
-| `quality` | string | No | Quality indicator. Defaults to `"Good"` if omitted. |
-| `timestamp` | string | No | RFC 3339 timestamp. Defaults to server time if omitted. |
+| `updates` | array | Yes | Array of elementId/value pairs to write |
+| `updates[].elementId` | string | Yes | The elementId of the Object to update |
+| `updates[].value` | object | Yes | The VQT value to write. `value` must conform to the Object's type schema. `null` is permitted for nullable fields — see [Null Value Handling](#null-value-handling). |
+| `updates[].value.value` | any | Yes | The data value to write |
+| `updates[].value.quality` | string | No | Quality indicator. Defaults to `"Good"` if omitted. |
+| `updates[].value.timestamp` | string | No | RFC 3339 timestamp. Defaults to server time if omitted. |
 
 ```json
 {
-  "value": { "temperature": 20, "unit": "C" },
-  "quality": "Good",
-  "timestamp": "2025-01-08T10:30:00Z"
+  "updates": [
+    {
+      "elementId": "pump-101",
+      "value": {
+        "value": { "temperature": 20, "unit": "C" },
+        "quality": "Good",
+        "timestamp": "2025-01-08T10:30:00Z"
+      }
+    }
+  ]
 }
 ```
 
 **Response:**
 
+Returns a bulk response with a result per elementId.
+
 ```json
 {
   "success": true,
-  "result": null
+  "results": [
+    { "success": true, "elementId": "pump-101", "result": null },
+    { "success": false, "elementId": "bad-id", "problemDetail": { "title": "Not Found", "status": 404, "detail": "Element not found: bad-id" } }
+  ]
 }
 ```
 
 ---
 
-#### `PUT` /objects/{elementId}/history
+#### `POST` /objects/history/update
 
-Update historical values of an Object.
+Update historical values of one or more Objects.
 
-**Path Parameters:**
-
-| Name | Type | Required | Description |
-|------|------|----------|-------------|
-| `elementId` | string | Yes | The elementId of the Object to update |
+> **Note:** This endpoint is defined by the specification but not yet implemented by this server. It returns HTTP 501.
 
 **Request Body:**
 
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `updates` | array | Yes | Array of elementId/value pairs to write |
+| `updates[].elementId` | string | Yes | The elementId of the Object to update |
+| `updates[].value` | object | Yes | A VQT object. The `timestamp` field identifies which historical record to create or replace. |
+| `updates[].value.value` | any | Yes | The data value to write |
+| `updates[].value.quality` | string | Yes | Quality indicator |
+| `updates[].value.timestamp` | string | Yes | RFC 3339 timestamp of the historical record to write |
+
 ```json
-// TODO document this
+{
+  "updates": [
+    {
+      "elementId": "pump-101",
+      "value": {
+        "value": { "temperature": 19.5, "unit": "C" },
+        "quality": "Good",
+        "timestamp": "2025-01-07T08:00:00Z"
+      }
+    }
+  ]
+}
 ```
 
 **Response:**
 
+Returns a bulk response with a result per elementId.
+
 ```json
-// TODO document this
+{
+  "success": true,
+  "results": [
+    { "success": true, "elementId": "pump-101", "result": null }
+  ]
+}
 ```
 
 ---

--- a/spec/IMPLEMENTATION_GUIDE.md
+++ b/spec/IMPLEMENTATION_GUIDE.md
@@ -170,19 +170,15 @@ Failures return an HTTP error code with the following shape. The `responseDetail
     "detail": "Element not found: pump-101"
   }
 }
+```
 | Field                    | Type    | Required | Description                                                             |
 |--------------------------|---------|----------|-------------------------------------------------------------------------|
 | `success`                | boolean | Yes      | `false` for any error response.                                         |
-
 | `responseDetail.title`    | string  | Yes      | Short, human-readable summary of the problem type (e.g. `"Not Found"`). |
 | `responseDetail.status`   | number  | Yes      | The HTTP status code.                                                   |
 | `responseDetail.detail`   | string  | Yes      | Human-readable explanation specific to this occurrence.                 |
 
-Failures (`success: false`) MUST include `responseDetail`:
-
-```
-
-The following HTTP status codes are used.
+The following HTTP status codes are used:
 
 | Code | Meaning | When to Use |
 |------|---------|-------------|

--- a/spec/IMPLEMENTATION_GUIDE.md
+++ b/spec/IMPLEMENTATION_GUIDE.md
@@ -757,7 +757,7 @@ Returns a list of all Objects, optionally filtered by `typeElementId`. This allo
           "HasParent": "/",
           "HasChildren": ["child1", "child2"]
         },
-        "extendedAttributes": {
+        "schemaExtensions": {
           "serial_number": { "type": "string" },
           "firmware_version": { "type": "string" }
         },
@@ -779,7 +779,7 @@ Returns a list of all Objects, optionally filtered by `typeElementId`. This allo
 | `typeElementId` | string  | Yes      | ElementId of the Object Type that defines this Object's schema                                                                                                                                                         |
 | `parentId`      | string? | Yes      | ElementId of the parent Object in the organizational hierarchy; `null` if this is a root Object                                                                                                                        |
 | `isComposition` | boolean | Yes      | `true` if this Object encapsulates composed child elements (HasComponent). Composition children contribute to the parent's value and are returned together under `components` when reading values with `maxDepth > 1`. |
-| `isExtended`    | boolean | Yes      | `true` if the Object's current value contains attributes not declared in its ObjectType schema. The Object carries data the type doesn't describe. See `extendedAttributes` below in the `metadata`.                   |
+| `isExtended`    | boolean | Yes      | `true` if the Object's current value contains attributes not declared in its ObjectType schema. The Object carries data the type doesn't describe. See `schemaExtensions` below in the `metadata`.                   |
 
 The `metadata` key is included if `includeMetadata=true` in the request.
 
@@ -789,7 +789,7 @@ The `metadata` key is included if `includeMetadata=true` in the request.
 | `metadata.typeNamespaceUri`   | string  | Yes                      | The namespace the ObjectType *definition* belongs to — identifies which namespace's schema this Object conforms to (e.g., an ISA-95 or OPC UA standard namespace, or a vendor namespace). An Object instance's type may come from any namespace; this field makes that provenance explicit. For example, if the external Namespace was the OPC UA for Machinery Companion spec, the typeNamespaceUri would be `http://opcfoundation.org/UA/Machinery/`. |
 | `metadata.sourceTypeId`       | string  | Yes                      | An identifier of this type within its *source namespace*. Provided so clients can correlate back to the originating definition. Distinct from `typeElementId`, which is the i3X address space identifier. For example, if the external Type was JobOrderControl from the OPC UA for Machinery Companion spec, the typeElementId may be the BrowseName, `JobOrderControl` OR the NodeId `ns=1;i=5058`. |
 | `metadata.relationships`      | object  | No                       | The Object's outgoing relationship edges, keyed by relationship type. Enables clients to plan graph traversal without an additional `/objects/related` call. Only elementIds are returned here; use `/objects/related` to get the full related Object records. |
-| `metadata.extendedAttributes` | object  | No                       | Present only when `isExtended=true`. Contains the non-conformant attributes and their inferred JSON Schema fragments, keyed by attribute name. Declared (conformant) attributes are omitted — they can be looked up from the `typeElementId`. |
+| `metadata.schemaExtensions` | object  | No                       | Present only when `isExtended=true`. Contains the non-conformant attributes and their inferred JSON Schema fragments, keyed by attribute name. Declared (conformant) attributes are omitted — they can be looked up from the `typeElementId`. |
 |  `metadata.system`            | object | Yes if `isExtended=true` | Vendor-defined key/value pairs for platform-specific metadata not covered by the standard fields. Keys are vendor-defined strings; values are limited to strings, numbers, and booleans.|
 
 


### PR DESCRIPTION
Remove single-element GET/PUT path endpoints; replace with POST body equivalents to address #296

### Problem
ElementIds can contain URL-special characters (slashes, colons, query separators, etc.). Encoding them into URL path segments is challenging for clients - the existing unquote() workaround is a band-aid, not a solution.

### Proposed Solution

**Removed:**
- `GET /objects/{elementId}/history` — redundant with the existing POST /objects/history (same capability, already bulk-capable)
- `PUT /objects/{elementId}/value` — _replaced_ with POST defined below   
- `PUT /objects/{elementId}/history` — _replaced_ with the correct endpoint shape defined below for when the feature is implemented

**Added:**
- `POST /objects/value/update` — writes current values; accepts elementIds in the request body
- `POST /objects/history/update` — writes historical values; accepts elementIds in the request body (returns 501 until implemented)

Request shape (match with all other bulk endpoints): 
``` 
  {
    "updates": [
      { "elementId": "...", "value": { "value": ..., "quality": "Good", "timestamp": "..." } } 
    ]
  }
```

Response shape — match bulk envelope used everywhere else:
```
  { 
    "success": true,
    "results": [
      { "success": true, "elementId": "...", "result": null },       
      { "success": false, "elementId": "...", "problemDetail": { ... } }
    ] 
  }  
 ```

### Rationale

Every other elementId-bearing endpoint in the API already accepts elementIds in the POST body. This change makes the update endpoints consistent with that pattern. 
The {elementId} path parameter endpoints were the last remaining outliers. The updates array shape mirrors the read-side bulk response — one item per element, success or failure reported individually — so the read/write calling convention is symmetric.  