### PR TITLE
Issue 295: Updated subscription /sync examples

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 This repository contains the RFC 001 specification and prototype implementation for i3X (Industrial Information Interface eXchange) - a common API for information platforms. The goal is to enable portable application development across different manufacturing information platforms by providing a vendor-agnostic API specification.
 
 **Key Documents:**
-- `IMPLEMENTATION_GUIDE.md` - The guide that will eventually become the specification
+- `spec/IMPLEMENTATION_GUIDE.md` - The guide that will eventually become the specification
 - `RFC for Contextualized Manufacturing Information API.md` - Complete RFC 001 specification defining the i3X API
 - `Working Group Charter.md` - Charter for the Smart Manufacturing API Working Group
 - `README.md` - High-level project overview and problem statement

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Changes accepted between 1.0 Beta and the 1.0 Release.
 All notable changes to the i3X RFC, Implementation Guide, and demo are documented here so that implementers can identify the exact deltas they need to adopt.
 
 ## Summary
+- 2026-05-22 — `/subscriptions/sync` response restructured: updates are now grouped into batches — `[{"sequenceNumber": N, "updates": [...]}]` — rather than a flat list where each update carried its own `sequenceNumber` | [#295](https://github.com/cesmii/i3X/issues/295)
+- 2026-05-22 — Subscription management endpoints restructured: `GET /subscriptions` and `GET /subscriptions/{id}` replaced by `POST /subscriptions/list`; `DELETE /subscriptions/{id}` replaced by `POST /subscriptions/delete`; `GET /subscriptions/stream` changed to `POST`. All subscription operations now require `clientId` in the request body for client scoping | [#295](https://github.com/cesmii/i3X/issues/295)
 - 2026-04-29 — `responseDetail` replaces `problemDetail` as the response envelope field for error and partial-success details | [#294](https://github.com/cesmii/i3X/issues/294)
 - 2026-04-28 — `PUT /objects/{elementId}/value` and `PUT /objects/{elementId}/history` replaced by `PUT /objects/value` and `PUT /objects/history`, accepting elementIds in the request body as `{"updates": [{"elementId": "...", "value": {...}}, ...]}` and returning bulk responses. `GET /objects/{elementId}/history` removed — use `POST /objects/history` instead. (RFC §4.2.2, Implementation Guide, demo server)
 - 2026-04-28 — `extendedAttributes` renamed to `schemaExtensions` in the object metadata response (RFC §3.1.1, Implementation Guide, and demo server)

--- a/RFC for Contextualized Manufacturing Information API.md
+++ b/RFC for Contextualized Manufacturing Information API.md
@@ -254,7 +254,7 @@ The contributors to this RFC, and the broader community, have communicated clear
 
 ##### 4.2.3.1 Create Subscription
 
-Registers a client for a new Subscription. The client MUST provide a unique `clientId` to scope the subscription to the client. The response MUST include a server-generated `subscriptionId` scoped to the `clientId`; only the owning client may access the subscription. Implementations SHALL support two delivery modes.
+Registers a client for a new Subscription. The client MUST provide a unique `clientId` to scope the subscription to the client. The response MUST include a server-generated `subscriptionId` scoped to the `clientId`; only the owning client may access the subscription. Implementations MUST support the Sync delivery mode. Implementations MAY support the Streaming delivery mode.
 
 ###### Streaming: At Most Once
 

--- a/RFC for Contextualized Manufacturing Information API.md
+++ b/RFC for Contextualized Manufacturing Information API.md
@@ -215,7 +215,7 @@ When the LastKnownValue interface is invoked with an array of ElementIds, the re
 
 ##### 4.2.1.2 Object Element HistoricalValue
 
-When invoked as a Query, the HistoricalValue interface MUST return an array of historical values in a time range available in the contextualized information platform for the requested object, by ElementId.
+When invoked as a Query, the HistoricalValue interface MUST return an array of historical values in any time range that is available in the contextualized information platform for the requested object, by ElementId.
 
 When invoked as a Query, the HistoricalValue interface MAY support an array of requested object ElementIds to reduce round-trips where multiple values are required by an application, in which case, the return payload MUST be an array of arrays.
 
@@ -262,7 +262,7 @@ The implementation will publish messages to subscribed clients as the data becom
 
 ###### Sync: At Least Once
 
-The server queues updates as they occur, each assigned a monotonically increasing sequence number. The client polls to receive pending updates and acknowledges receipt by providing the highest sequence number processed. The server removes acknowledged updates and returns any remaining queue in the same call. Servers SHOULD queue updates FIFO and MAY drop the oldest updates when a server-imposed queue limit is reached.
+The server queues updates as they occur, each assigned an increasing sequence number. The client polls to receive pending updates and acknowledges receipt by providing the highest sequence number processed. The server removes acknowledged updates and returns any remaining queue in the same call. Servers SHOULD queue updates FIFO and MAY drop the oldest updates when a server-imposed queue limit is reached.
 
 Implementations MUST also support listing existing subscriptions by ID and deleting subscriptions to release server resources.
 
@@ -300,14 +300,14 @@ This method is used only for sync subscriptions, and is called with a specific S
 
 When servicing the Sync call, the implementation MUST respond with an array of updates for elements that have changed since the last Sync call. Each update in the response array MUST include:
 - elementId: the ElementId of the changed element
-- sequenceNumber: the monotonically increasing sequence number assigned to this update
+- sequenceNumber: the increasing sequence number assigned to this update
 - value: the new value (with recursive structure if maxDepth was specified during registration)
 - quality: the quality indicator
 - timestamp: the timestamp of the change
 
 If no elements have changed since the last Sync call, the response MUST be an empty array.
 
-Each update in the queue carries a monotonically increasing `sequenceNumber`. The client MAY include a `lastSequenceNumber` in the Sync call to acknowledge all updates with a sequence number at or below that value; the implementation MUST remove those acknowledged updates before returning the remaining queue. If `lastSequenceNumber` is omitted the implementation MUST NOT clear the queue. The implementation must maintain state for all pending (un-acknowledged) updates, subject to server-imposed queue limits.
+Each update in the queue carries an increasing `sequenceNumber`. The client MAY include a `lastSequenceNumber` in the Sync call to acknowledge all updates with a sequence number at or below that value; the implementation MUST remove those acknowledged updates before returning the remaining queue. If `lastSequenceNumber` is omitted the implementation MUST NOT clear the queue. The implementation must maintain state for all pending (un-acknowledged) updates, subject to server-imposed queue limits.
 
 When the server drops updates due to queue limits, it MUST signal data loss to the client by returning HTTP 206 (Partial Content) instead of HTTP 200. The response body MUST use `"success": true` with the standard `result` payload and an additional top-level `responseDetail` object. The `responseDetail` object MUST include the following fields:
 - `title`: a short human-readable summary of the problem

--- a/demo/server/models.py
+++ b/demo/server/models.py
@@ -313,13 +313,17 @@ class HistoricalValueResult(BaseModel):
     values: List[VQT] = Field(..., description="Ordered array of VQT objects for the requested time range")
 
 
-class SyncUpdate(BaseModel):
+class SyncUpdateEntry(BaseModel):
     model_config = ConfigDict(extra='allow')
-    sequenceNumber: int
     elementId: str
     value: Any
     quality: str = Field(..., description="Data quality indicator: Good, GoodNoData, Bad, or Uncertain")
     timestamp: str = Field(..., description="RFC 3339 UTC timestamp when this value was recorded")
+
+
+class SyncBatch(BaseModel):
+    sequenceNumber: int
+    updates: List[SyncUpdateEntry]
 
 
 class SubscriptionDetail(BaseModel):

--- a/demo/server/routers/subscriptions.py
+++ b/demo/server/routers/subscriptions.py
@@ -4,6 +4,7 @@ from typing import List, Optional, Any, Callable, Dict
 from datetime import datetime, timezone
 import asyncio
 import json
+import queue as thread_queue
 import time
 import uuid
 from pydantic import BaseModel, Field, ConfigDict
@@ -16,7 +17,7 @@ from models import (
     CreateSubscriptionResponse,
     SuccessResponse,
     BulkResponse,
-    SyncUpdate,
+    SyncBatch,
     SubscriptionDetail,
 )
 from .utils import getSubscriptionValue, success_response, bulk_response, get_data_source, BASE_ERROR_RESPONSES, NOT_FOUND_RESPONSE
@@ -31,11 +32,12 @@ class Subscription(BaseModel):
     displayName: Optional[str] = None
     created: str
     monitoredObjects: List[dict] = []  # Each entry: {"elementId": str, "maxDepth": int}
-    pendingUpdates: List[Any] = []  # Queue for updates (max 1000, FIFO). Each item: {sequenceNumber, elementId, value, quality, timestamp}
+    stagedUpdates: List[Any] = []  # Raw updates queued from data source, not yet batched. Each item: {elementId, value, quality, timestamp}
+    batches: List[Any] = []        # Batched updates returned to client but not yet acked. Each item: {sequenceNumber, updates: [...]}
     max_queue_size: int = 1000
-    nextSequence: int = 1           # Sequence number for the next queued update
+    nextSequence: int = 1           # Sequence number for the next batch created on /sync
     lastAckedSequence: int = 0      # Highest sequence number acknowledged by the client
-    droppedCount: int = 0           # Updates dropped from the queue since last client ack
+    droppedCount: int = 0           # Updates dropped from stagedUpdates since last client ack
     ttl_seconds: int = 300          # Idle TTL: subscription auto-deleted if no /sync or active stream within this window
     last_activity: str = ""         # ISO timestamp of last /sync, /ack, or stream open
     is_streaming: bool = False  # True when SSE connection is active
@@ -170,15 +172,19 @@ async def stream_subscription(request: Request, req: StreamRequest):
     if sub.handler is not None and sub.streaming_response is not None:
         return sub.streaming_response
 
-    # Otherwise create queue, loop, handler, and streaming response once
-    queue = asyncio.Queue()
-    loop = asyncio.get_event_loop()
+    # Otherwise create queue, handler, and streaming response once.
+    # Use a threading.Queue so the MockDataUpdater thread can push without any
+    # event-loop cross-thread coordination (asyncio.Queue is not thread-safe).
+    tq: thread_queue.Queue = thread_queue.Queue()
 
     async def event_stream():
         try:
             while True:
-                update = await queue.get()
-                yield f"data: {json.dumps([update])}\n\n"
+                try:
+                    update = tq.get_nowait()
+                    yield f"data: {json.dumps([update])}\n\n"
+                except thread_queue.Empty:
+                    await asyncio.sleep(0.05)
         except Exception as e:
             print(f"[SSE] Stream ended: {e}")
         finally:
@@ -190,19 +196,20 @@ async def stream_subscription(request: Request, req: StreamRequest):
             print(f"[SSE] Subscription {req.subscriptionId} switched back to queue mode")
 
     def push_update_to_client(update):
-        asyncio.run_coroutine_threadsafe(queue.put(update), loop)
+        tq.put(update)
 
     # Switch to streaming mode
     sub.last_activity = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     sub.is_streaming = True
     sub.handler = push_update_to_client
-    sub.event_loop = loop
+    sub.event_loop = None
     sub.streaming_response = StreamingResponse(
         event_stream(), media_type="text/event-stream"
     )
 
-    # Clear the queue when switching to streaming (per requirements)
-    sub.pendingUpdates.clear()
+    # Clear staged updates when switching to streaming — client will receive live SSE going forward
+    sub.stagedUpdates.clear()
+    sub.batches.clear()
 
     return sub.streaming_response
 
@@ -212,7 +219,7 @@ async def stream_subscription(request: Request, req: StreamRequest):
     "/subscriptions/sync",
     summary="Sync Values",
     operation_id="syncSubscription",
-    response_model=SuccessResponse[List[SyncUpdate]],
+    response_model=SuccessResponse[List[SyncBatch]],
     responses={
         206: {"description": PARTIAL_CONTENT_DESCRIPTION},
         **NOT_FOUND_RESPONSE,
@@ -220,50 +227,53 @@ async def stream_subscription(request: Request, req: StreamRequest):
     },
 )
 def sync_subscription(request: Request, req: SyncRequest):
-    """Acknowledge previously received updates and return all pending updates in one call.
+    """Acknowledge previously received batches and return all pending batches in one call.
 
-    If `lastSequenceNumber` is provided, all queued updates with sequenceNumber <= lastSequenceNumber are removed first,
-    then the remaining (newer) updates are returned. Returns HTTP 206 if updates were dropped from the queue since
-    the client's last acknowledged sequence number. subscriptionId is passed in the request body.
+    If `lastSequenceNumber` is provided, all batches with sequenceNumber <= lastSequenceNumber are
+    removed first (acknowledged). Any staged updates are then bundled into a new batch and appended.
+    Returns HTTP 206 if updates were dropped from the staging queue due to overflow.
+    subscriptionId is passed in the request body.
     """
     sub = _find_sub(request, req.subscriptionId, req.clientId)
     if not sub:
         raise HTTPException(status_code=404, detail="Subscription not found")
 
+    # Acknowledge batches the client has already processed
     if req.lastSequenceNumber is not None:
-        sub.pendingUpdates = [u for u in sub.pendingUpdates if u.get("sequenceNumber", 0) > req.lastSequenceNumber]
+        sub.batches = [b for b in sub.batches if b.get("sequenceNumber", 0) > req.lastSequenceNumber]
         sub.lastAckedSequence = max(sub.lastAckedSequence, req.lastSequenceNumber)
 
-    # Detect data loss: explicit drop counter or a sequence gap between the last ack and first available update
+    # Detect data loss before resetting the counter
     has_drops = sub.droppedCount > 0
-    if not has_drops and sub.pendingUpdates and req.lastSequenceNumber is not None:
-        first_seq = sub.pendingUpdates[0].get("sequenceNumber", 0)
-        has_drops = first_seq > req.lastSequenceNumber + 1
-
-    # Reset drop counter now that the client is being informed
     sub.droppedCount = 0
 
+    # Bundle any staged updates into a new batch
+    if sub.stagedUpdates:
+        new_batch = {"sequenceNumber": sub.nextSequence, "updates": list(sub.stagedUpdates)}
+        sub.batches.append(new_batch)
+        sub.nextSequence += 1
+        sub.stagedUpdates.clear()
+
     sub.last_activity = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-    updates = list(sub.pendingUpdates)
+    batches = list(sub.batches)
 
     if has_drops:
+        first_seq = batches[0]["sequenceNumber"] if batches else sub.nextSequence
         body = {
             "success": True,
-            "result": updates,
+            "result": batches,
             "responseDetail": {
                 "title": "Updates dropped due to queue overflow",
                 "status": 206,
                 "detail": (
-                    "Updates were dropped from the subscription queue because the server-imposed "
-                    "queue limit was reached. The client may assume that all sequence numbers "
-                    "between its last acknowledged sequence number and the first returned sequence "
-                    "number were dropped."
+                    f"Updates were dropped from the subscription queue because the server-imposed "
+                    f"queue limit was reached. Updates prior to sequence number {first_seq} were lost."
                 ),
             },
         }
         return JSONResponse(content=body, status_code=206)
 
-    return success_response(updates)
+    return success_response(batches)
 
 
 # POST /subscriptions/delete - Delete one or more subscriptions
@@ -354,18 +364,13 @@ def handle_data_source_update(instance, value, I3X_DATA_SUBSCRIPTIONS, data_sour
                         sub.is_streaming = False
                         sub.handler = None
                 else:
-                    # Queue mode: store for later /sync retrieval
+                    # Queue mode: stage for later batching on /sync
                     update_value = getSubscriptionValue(instance, value, maxDepth=monitored["maxDepth"], data_source=data_source)
-                    queued_item = {
-                        "sequenceNumber": sub.nextSequence,
-                        **update_value,
-                    }
-                    sub.nextSequence += 1
-                    # Enforce FIFO with max queue size — oldest update is dropped first
-                    if len(sub.pendingUpdates) >= sub.max_queue_size:
-                        sub.pendingUpdates.pop(0)
+                    # Enforce FIFO with max queue size — oldest staged update is dropped first
+                    if len(sub.stagedUpdates) >= sub.max_queue_size:
+                        sub.stagedUpdates.pop(0)
                         sub.droppedCount += 1
-                    sub.pendingUpdates.append(queued_item)
+                    sub.stagedUpdates.append(update_value)
     except Exception as e:
         import traceback
         print(f"Error routing data source update: {e}\n{traceback.format_exc()}")

--- a/spec/IMPLEMENTATION_GUIDE.md
+++ b/spec/IMPLEMENTATION_GUIDE.md
@@ -74,7 +74,7 @@ Below are the required capabilities for all i3X compliant Clients and Servers.
 * Subscribe
   * MUST support base [Subscribe Methods](#subscribe-methods) (create, delete, list, register objects, unregister objects)
   * MUST support Sync (`/subscriptions/sync`)
-  * SHOULD support Stream (`/subscriptions/stream`)
+  * MAY support Stream (`/subscriptions/stream`)
   
 ## Transport & Encoding
 
@@ -1329,15 +1329,18 @@ Returns a bulk response with a result per elementId.
 
 ## Subscribe Methods
 
-Subscriptions allow clients to receive value changes in real-time for objects they are interested in. Subscriptions support two delivery modes:
+Subscriptions allow clients to receive the most recent values of objects they are interested in. Subscriptions support two delivery modes:
 
-| Mode | Description |
-|------|-------------|
-| **streaming** | Value changes are sent as fast as possible using SSE (Server Sent Events). |
-| **sync** | Value changes are queued and delivered when the client calls the sync API. |
+| Mode | Required | Description |
+|------|----------|-------------|
+| **sync** | MUST | Clients poll for batched updates; the server acknowledges delivery for high Quality of Service. |
+| **streaming** | MAY | The server pushes updates as they occur using SSE for low Quality of Service. |
 
-Streaming provides data as fast as possible, where Sync allows the client to control when data is delivered and acknowledge delivery. The following
-sections describe common methods to setup and configure a subscription, followed by more details on the stream and sync modes.
+Sync is the baseline delivery mode and MUST be supported by all servers. Streaming MAY be supported when the underlying data source provides real-time push notifications; see the note in the [Streaming](#streaming) section.
+
+> **Implementation note for non-real-time sources:** Servers backed by a historian, database, or other non-push data source MAY satisfy the sync requirement by reading the most recent value for each registered object at the time `/sync` is called, rather than maintaining a live change queue. The response format is identical — only the update granularity differs. Clients will observe the latest available value on each sync call, but intermediate changes between calls may not be captured.
+
+The following sections describe common methods to set up and configure a subscription, followed by more details on the stream and sync modes.
 
 ### Subscriptions
 
@@ -1502,7 +1505,7 @@ Register one or more Objects with a Subscription.
 | `clientId` | string | Yes | The clientId for the subscription. |
 | `subscriptionId` | string | Yes | The subscriptionId to register items with. |
 | `elementIds` | string[] | Yes | One or more elementIds to register. |
-| `maxDepth` | integer | No | Controls recursion depth. [TODO] - MGP explain how maxDepth works. Similar to values, where it only follows hasComponent relationships? |
+| `maxDepth` | integer | No | Controls recursion depth. See [maxDepth](#maxdepth-parameter-semantics) for more detail. |
 
 **Response:**
 
@@ -1563,7 +1566,9 @@ Unregister one or more Objects from a Subscription.
 
 ### Streaming
 
-Streaming sends values on the subscription to the client as they occur using SSE (Server Sent Events) for a low Quality of Service.
+Streaming sends values as they occur using SSE (Server Sent Events) and MAY be supported when the underlying data source can push updates in real time. Streaming provides low Quality of Service — at-most-once delivery with no acknowledgement.
+
+> **Implementation note:** Streaming requires a data source capable of push notifications. Servers that use a polling-based sync implementation (see the note in [Subscribe Methods](#subscribe-methods)) SHOULD return HTTP 501 for `/subscriptions/stream`.
 
 **How it works:**
 
@@ -1620,7 +1625,7 @@ Sync allows the client to control when value changes are received, and to explic
 
 1. Client creates subscription via `POST /subscriptions`
 2. Client registers objects via `POST /subscriptions/register`
-3. Server queues object updates as they occur
+3. Server queues object updates as they occur, or — for non-push sources — captures the latest value at sync time
 4. Client polls via `POST /subscriptions/sync` (no `lastSequenceNumber` on first call)
 5. Server returns all pending updates with a `sequenceNumber=1`
 6. Client processes the updates
@@ -1865,4 +1870,4 @@ When `maxDepth > 1` and the element has components:
 
 ---
 
-*Copyright (C) CESMII, the Smart Manufacturing Institute, 2024-2025. All Rights Reserved.*
+*Copyright (C) CESMII, the Smart Manufacturing Institute, 2024-2026. All Rights Reserved.*

--- a/spec/IMPLEMENTATION_GUIDE.md
+++ b/spec/IMPLEMENTATION_GUIDE.md
@@ -1631,13 +1631,13 @@ This approach ensures updates are not lost if the client crashes between receivi
 
 Returns all pending updates, acknowledging a previously received batch in the same call.
 
-- Each queued update includes a `sequenceNumber`
-- If `lastSequenceNumber` is provided, the server removes all updates with sequenceNumber ≤ `lastSequenceNumber` before returning the remaining queue
-- Server MUST NOT clear the queue if `lastSequenceNumber` is omitted
-- Server MUST return an empty array and no `sequenceNumber` if there are no new updates since the last `/sync` call
-- Servers SHOULD increment the `sequenceNumber` on each call to `sync` when there are new updates
-- Clients SHOULD omit `lastSequenceNumber` only on the first call, when there is nothing to acknowledge
+- Server MUST provide an incrementing `sequenceNumber` for new updates returned in the `/sync` response
+- The `sequenceNumber` MUST be a 64-bit unsigned integer to avoid rollover (2⁶⁴ − 1)
+- Clients SHOULD omit `lastSequenceNumber` on the first call, when there is nothing to acknowledge
 - Clients SHOULD provide `lastSequenceNumber` on every subsequent call, set to the highest `sequenceNumber` received in the previous response
+- Server MUST remove all updates with sequenceNumber ≤ `lastSequenceNumber` from the response
+- Server MUST NOT clear the queue if `lastSequenceNumber` is omitted or is invalid
+- Server MUST return an empty array and no `sequenceNumber` if there are no new updates since the last `/sync` call
 
 **Body Parameters:**
 

--- a/spec/IMPLEMENTATION_GUIDE.md
+++ b/spec/IMPLEMENTATION_GUIDE.md
@@ -1616,54 +1616,16 @@ Sync allows the client to control when value changes are received, and to explic
 **How it works:**
 
 1. Client creates subscription via `POST /subscriptions`
-2. Client registers items via `POST /subscriptions/register`
-3. Server queues updates as they occur, each assigned a monotonically increasing `sequenceNumber`.  Each subscription uses a different `sequenceNumber` where the first update within a new subscription sets `sequenceNumber=1`.  `sequenceNumber` is a 64-bit unsigned integer so rollover happens after 2⁶⁴ − 1
+2. Client registers objects via `POST /subscriptions/register`
+3. Server queues object updates as they occur
 4. Client polls via `POST /subscriptions/sync` (no `lastSequenceNumber` on first call)
-5. Server returns all pending updates
+5. Server returns all pending updates with a `sequenceNumber=1`
 6. Client processes the updates
-7. Client calls `POST /subscriptions/sync` again with `{"clientId": "...", "subscriptionId": "...", "lastSequenceNumber": <lastSequenceNumber>}` to acknowledge the previous batch and receive any new updates in a single round trip
-8. Server removes acknowledged updates (sequenceNumber ≤ `lastSequenceNumber`) then returns the remaining queue
+7. Client calls `POST /subscriptions/sync` again with `lastSequenceNumber: 1` to acknowledge the previous batch and receive any new updates in a single round trip
+8. Server removes acknowledged updates (`lastSequenceNumber` ≤ 1) then returns the remaining queue with `sequenceNumber=2`
 9. Continue this process
 
 This approach ensures updates are not lost if the client crashes between receiving and processing data, while keeping acknowledgement and polling as a single call.
-
-#### Queue Overflow and Partial Responses
-
-Servers maintain a queue for each subscription. When the queue is full and a new update arrives, the server MUST drop the oldest pending update to make room. If a client polls infrequently relative to the rate of change, it may miss updates.
-
-When the server has dropped updates since the client's last acknowledged sequence number, it MUST return **HTTP 206 (Partial Content)**. The response body has the same shape as a normal 200, with one addition: a `responseDetail` object:
-
-```json
-HTTP 206
-{
-  "success": true,
-  "result": [
-    {"sequenceNumber": 151, "elementId": "sensor-001", "value": 72.5, "quality": "Good", "timestamp": "2025-01-08T10:30:01Z"}
-  ],
-  "responseDetail": {
-    "title": "Updates dropped due to queue overflow",
-    "status": 206,
-    "detail": "Updates were dropped from the subscription queue because the server-imposed queue limit was reached. The client may assume that all sequence numbers between its last acknowledged sequence number and the first returned sequence number were dropped."
-  }
-}
-```
-
-**Inferring dropped sequence numbers:**
-
-The `sequenceNumber` on each update is monotonically increasing per update for a given subscription. When receiving an HTTP 206 response, a client can determine exactly which updates were lost by inspecting the :
-
-> All sequence numbers between `lastSequenceNumber + 1` and `result[0].sequenceNumber - 1` were dropped.
-
-For example, if the client's last call used `"lastSequenceNumber": 100` and the first update in the 206 response has `"sequenceNumber": 151`, then the 50 updates with sequence numbers 101–150 are permanently gone.
-
-**Client requirements on 206:**
-
-- Clients MUST process returned updates in the `result` array normally
-- Clients MUST continue polling with the highest returned `sequenceNumber` as the next `lastSequenceNumber`
-- Clients MUST NOT attempt to retrieve dropped updates — they are no longer unavailable
-- Clients SHOULD log or raise an alert when a 206 is received, as it indicates data loss
-
----
 
 #### `POST` /subscriptions/sync
 
@@ -1672,7 +1634,9 @@ Returns all pending updates, acknowledging a previously received batch in the sa
 - Each queued update includes a `sequenceNumber`
 - If `lastSequenceNumber` is provided, the server removes all updates with sequenceNumber ≤ `lastSequenceNumber` before returning the remaining queue
 - Server MUST NOT clear the queue if `lastSequenceNumber` is omitted
-- Clients SHOULD omit `lastSequenceNumber` only on the first call, when there is nothing yet to acknowledge
+- Server MUST return an empty array and no `sequenceNumber` if there are no new updates since the last `/sync` call
+- Servers SHOULD increment the `sequenceNumber` on each call to `sync` when there are new updates
+- Clients SHOULD omit `lastSequenceNumber` only on the first call, when there is nothing to acknowledge
 - Clients SHOULD provide `lastSequenceNumber` on every subsequent call, set to the highest `sequenceNumber` received in the previous response
 
 **Body Parameters:**
@@ -1683,7 +1647,9 @@ Returns all pending updates, acknowledging a previously received batch in the sa
 | `subscriptionId` | string | Yes | The subscriptionId for the Subscription to sync. |
 | `lastSequenceNumber` | 64-bit unsigned integer | No — omit only on first call | Acknowledge all updates with sequenceNumber ≤ this value before returning new ones. |
 
-First call (nothing to acknowledge yet):
+##### Sync Examples
+
+Assume the client setup the subscription and this is the first call to `/sync`. Note there is no `lastSequenceNumber`.
 ```json
 {
   "clientId": "myClient.eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
@@ -1691,7 +1657,46 @@ First call (nothing to acknowledge yet):
 }
 ```
 
-All subsequent calls (ack previous batch, fetch new):
+Server returns all pending updates with a sequence number.
+```json
+{
+  "success": true,
+  "result": [
+    {
+      "sequenceNumber": 1,
+      "updates": [
+        {"elementId": "sensor-001", "value": 72.5, "quality": "Good", "timestamp": "2025-01-08T10:30:00Z"},
+        {"elementId": "sensor-002", "value": 18.3, "quality": "Good", "timestamp": "2025-01-08T10:30:01Z"}
+      ]
+    }
+  ]
+}
+```
+
+Client calls `/sync` again with no `lastSequenceNumber`. The response includes updates from the previous sequenceNumber and the new updates.
+```json
+{
+  "success": true,
+  "result": [
+    {
+      "sequenceNumber": 1, 
+      "updates": [
+        {"elementId": "sensor-001", "value": 72.5, "quality": "Good", "timestamp": "2025-01-08T10:30:00Z"},
+        {"elementId": "sensor-002", "value": 18.3, "quality": "Good", "timestamp": "2025-01-08T10:30:01Z"}
+      ]
+    },
+    {
+      "sequenceNumber": 2,
+      "updates": [
+        {"elementId": "sensor-001", "value": 82.5, "quality": "Good", "timestamp": "2025-01-08T10:31:00Z"},
+        {"elementId": "sensor-002", "value": 28.3, "quality": "Good", "timestamp": "2025-01-08T10:31:01Z"}
+      ]
+    }
+  ]
+}
+```
+
+The client calls `/sync` again with `lastSequenceNumber=2`. 
 ```json
 {
   "clientId": "myClient.eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
@@ -1700,36 +1705,40 @@ All subsequent calls (ack previous batch, fetch new):
 }
 ```
 
-**Response (HTTP 200 — all updates delivered):**
-
+Assume there are no new updates. The server clears updates for sequenceNumber 1 and 2, and responds with no new updates.
 ```json
 {
   "success": true,
-  "result": [
-    {"sequenceNumber": 1, "elementId": "sensor-001", "value": 72.5, "quality": "Good", "timestamp": "2025-01-08T10:30:00Z"},
-    {"sequenceNumber": 2, "elementId": "sensor-002", "value": 18.3, "quality": "Good", "timestamp": "2025-01-08T10:30:01Z"}
-  ]
+  "result": []
 }
 ```
 
-**Response (HTTP 206 — some updates were dropped):**
+##### Sync Data Loss
 
+If the client does not call `/sync` frequently enough, the server's subscription queue may fill up and start dropping updates. 
+
+- The Server SHOULD drop the oldest updates first
+- The Server MUST return HTTP 206 (Partial Content) 
+
+Below is an example of a 206 response from the Server.
 ```json
 {
   "success": true,
   "result": [
-    {"sequenceNumber": 151, "elementId": "sensor-001", "value": 74.1, "quality": "Good", "timestamp": "2025-01-08T10:35:00Z"}
+    {
+      "sequenceNumber": 151,
+      "updates": [
+        {"elementId": "sensor-001", "value": 74.1, "quality": "Good", "timestamp": "2025-01-08T10:35:00Z"}
+      ]
+    }
   ],
   "responseDetail": {
     "title": "Updates dropped due to queue overflow",
     "status": 206,
-    "detail": "Updates were dropped from the subscription queue because the server-imposed queue limit was reached. The client may assume that all sequence numbers between its last acknowledged sequence number and the first returned sequence number were dropped."
+    "detail": "Updates were dropped from the subscription queue. The server limit is 10k updates."
   }
 }
 ```
-
-See [Queue Overflow and Partial Responses](#queue-overflow-and-partial-responses) for how to interpret a 206 response and recover from data loss.
-
 ---
 
 ### Subscription Life Cycle
@@ -1746,7 +1755,6 @@ This requirement prevents abandoned Subscriptions from consuming Server resource
 Once deleted, the Subscription SHALL NOT be returned by any API endpoint and MUST be re-created by the Client. Subsequent calls to `/sync` or `/stream` for a deleted or non-existent Subscription MUST return 404 Not Found.
 
 ---
-
 
 ## Appendix (for now)
 

--- a/spec/IMPLEMENTATION_GUIDE.md
+++ b/spec/IMPLEMENTATION_GUIDE.md
@@ -30,13 +30,15 @@ This document is a working draft, and should not be considered complete or norma
   - [Relationship Type Endpoints](#relationship-type-endpoints)
   - [Object Endpoints](#object-endpoints)
 - [Query Methods](#query-methods)
+  - [Null Value Handling](#null-value-handling)
 - [Update Methods](#update-methods)
 - [Subscribe Methods](#subscribe-methods)
   - [Subscriptions](#subscriptions)
   - [Registering and Unregistering Objects](#registering-and-unregistering-objects)
   - [Streaming](#streaming)
   - [Sync](#sync)
-    - [Queue Overflow and Partial Responses](#queue-overflow-and-partial-responses)
+    - [Sync Examples](#sync-examples)
+    - [Sync Data Loss](#sync-data-loss)
   - [Subscription Life Cycle](#subscription-life-cycle)
 - [Appendix](#appendix-for-now)
   - [Relationship Semantics](#relationship-semantics)
@@ -66,7 +68,7 @@ Below are the required capabilities for all i3X compliant Clients and Servers.
   * MUST support all [Exploratory Methods](#exploratory-methods)
 * Query
   * MUST support Current Value (`objects/value`) as defined in [Query Methods](#query-methods)
-  * MAY support History Value (`objects/history`)
+  * MUST support History Value (`objects/history`) — see note in [Query Methods](#query-methods)
 * Update
   * MAY support [Update Methods](#update-methods)
 * Subscribe
@@ -1004,7 +1006,7 @@ Values in i3X have the following definition.
 |-------|------|----------|-------------|
 | `value` | any | Yes | The actual data value (any JSON type) |
 | `quality` | string | Yes | Data quality indicator |
-| `timestamp` | string | Yes | RFC 3339 timestamp when data was recorded. Times must be UTC with no timezone offset. |
+| `timestamp` | string | Yes | RFC 3339 timestamp when data was recorded. Times MUST be UTC with no timezone offset. Fractional seconds are supported: `"2025-01-08T10:30:00.123456Z"`. |
 
 
 | Quality | Description | When to Use |
@@ -1160,9 +1162,10 @@ Returns the last known value for one or more Objects.
 
 #### `POST` /objects/history
 
-Returns the historical values for one or more Objects between a start and end time.
+> **Implementation note:** Not all implementations are required to become Historians; the intent is that whatever history the underlying platform already retains should be accessible through a consistent interface. A Historian, a cache, or no history at all should be accessed the same way.
+A server whose platform stores no history SHOULD still implement this endpoint and return `GoodNoData` for the requested range. Use `GET /info` `capabilities.query.history` to advertise whether historical data is available.
 
-[TODO] - Sync reponse with v0.1.2
+Returns the historical values for one or more Objects between a start and end time.
 
 **Request Body:**
 
@@ -1281,7 +1284,7 @@ Returns a bulk response with a result per elementId.
 
 Update historical values of one or more Objects.
 
-> **Note:** This endpoint is defined by the specification but not yet implemented by this server. It returns HTTP 501.
+> **Implementation note:** As with query history, implementations are not expected become Historians if they don't already have this capabilitiy. This endpoint allows clients to write historical records into whatever persistence the underlying platform supports. Servers whose platform does not support historical writes SHOULD return HTTP 501.
 
 **Request Body:**
 


### PR DESCRIPTION
This change to the guide is intended to makes it clearer that sequenceNumber is assigned & returned on the call to /sync for a collection of object updates since the last sync call & not assigned per object update inside the subscription.

In effect, it allows clients to replay /sync responses.