### PR TITLE
Add missing abstract method to MQTT demo data source

### DIFF
--- a/demo/server/data_sources/mqtt/mqtt_data_source.py
+++ b/demo/server/data_sources/mqtt/mqtt_data_source.py
@@ -609,7 +609,12 @@ class MQTTDataSource(I3XDataSource):
                 instances.append(instance)
 
         return instances
-    
+
+    def get_instance_extra_attributes(self, element_id: str) -> Optional[Dict[str, Any]]:
+        """
+        Return extra (non-schema) attributes for an instance by ElementId.
+        """
+        return {}
 
     # Helpers to respond to data source method calls above
 


### PR DESCRIPTION
The demo server falls back to the mock data source otherwise.

This closes #315 .