### PR TITLE
fix: prefer objects with Good values in SUB-03 registration

### DIFF
--- a/conformance-tests/lib/tests/subscribe.js
+++ b/conformance-tests/lib/tests/subscribe.js
@@ -134,7 +134,21 @@ module.exports = [
     async run(ctx) {
       if (!ctx.subscriptionId) return skip('No subscription was created', 'blocked');
       if (!ctx.objects || !ctx.objects.length) return skip('No objects available to register', 'blocked');
-      const ids = ctx.objects.slice(0, 2).map((o) => o.elementId);
+
+      // Prefer objects that had Good-quality current values during the QRY
+      // phase so that SUB-07/SUB-13 can observe sync updates and exercise
+      // acknowledgement semantics.  Fall back to the first objects if none
+      // with values are found (e.g. empty address spaces).
+      let candidates = ctx.objects;
+      if (ctx.currentValues && ctx.currentValues.size) {
+        const withValues = ctx.objects.filter((o) =>
+          ctx.currentValues.has(o.elementId) &&
+          ctx.currentValues.get(o.elementId).quality === 'Good'
+        );
+        if (withValues.length >= 2) candidates = withValues;
+      }
+      const ids = candidates.slice(0, 2).map((o) => o.elementId);
+
       const res = await ctx.client.request('POST', '/subscriptions/register', {
         body: { clientId: ctx.clientId, subscriptionId: ctx.subscriptionId, elementIds: ids }
       });


### PR DESCRIPTION
## Problem
The subscription conformance tests (SUB-03) register the **first 2 objects** from the discovery list:

```js
const ids = ctx.objects.slice(0, 2).map((o) => o.elementId);
```

On OPC UA-based servers, these are typically infrastructure nodes ("Locations", "Server") that have **zero child properties** and never produce value changes. This causes two MUST-level tests to always SKIP:

- **SUB-07** — `No updates were observed on the subscription`
- **SUB-13** — `No pending updates were observed`

This happens on **both** the Python (`i3x2ua`) and Node.js (`node-i3x`) reference implementations.
Related: #329, #299

## Changes

### SUB-03 — Smarter object selection

Prefer objects that were confirmed to have `Good`-quality current values during the QRY phase (`ctx.currentValues`). Falls back to the original `ctx.objects.slice(0, 2)` behavior when no objects with values are found.

### SUB-06 — Accept both sync response formats

The validator now accepts both:
- **Flat format** (`[{sequenceNumber, elementId, value, quality, timestamp}]`) — used by the Python reference implementation
- **Batch format** (`[{sequenceNumber, updates: [{elementId, value, quality, timestamp}]}]`) — defined in the OpenAPI spec
This is needed because once SUB-03 registers objects with actual values, SUB-06 will receive non-empty results and the shape validation will run for the first time.

## Testing

Tested against the Node.js OPC UA adapter ([node-opcua/node-i3x](https://github.com/node-opcua/node-i3x)):
- Before: 53 PASS, 0 FAIL, 4 SKIP (SUB-07, SUB-13 always skip)
- After: SUB-07 and SUB-13 become testable on servers with observable values